### PR TITLE
chore: update biome schema path

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "includes": ["**", "!**/*.snap.cjs", "!**/fixtures/**", "!**/expected/**", "!**/input/**"]
   },


### PR DESCRIPTION
To prevent Biome from warning about an incorrect schema version, update the Biome configuration to use the locally installed schema.

<img width="847" height="205" alt="Screenshot 2025-07-27 at 12 47 02" src="https://github.com/user-attachments/assets/d864bdfe-32a8-4fca-869b-32c2ffa3fa22" />
