### PR TITLE
setup(ci-publish): use `@next` codemod cli

### DIFF
--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -43,7 +43,7 @@ jobs:
           echo "CODEMOD_NAME=$CODEMOD_NAME" >> $GITHUB_OUTPUT
           echo "CODEMOD_PATH=recipes/$CODEMOD_NAME" >> $GITHUB_OUTPUT
 
-          echo "Publishing: $CODEMOD_NAME (version: $VERSION) from recipes/$CODEMOD_NAME"
+          echo "Publishing version $VERSION of $CODEMOD_NAME from recipes/$CODEMOD_NAME"
 
       - name: Validate codemod directory exists
         run: |

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -64,14 +64,15 @@ jobs:
       - name: Install Codemod CLI
         run: npm install -g codemod@next
 
+      # Run test first so if it's failing, we don't waste time to login and rest of thing
+      - name: Run test
+        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
+        run: node --run test
+
       - name: Login to Codemod registry
         env:
           CODEMOD_TOKEN: ${{ secrets.CODEMOD_TOKEN }}
         run: codemod login --token "$CODEMOD_TOKEN"
-
-      - name: Run test
-        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
-        run: node --run test
 
       - name: Publish codemod (dry run)
         working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -77,13 +77,13 @@ jobs:
           if [[ ! -d "$CODEMOD_PATH" ]]; then
             echo "❌ Codemod directory not found: $CODEMOD_PATH"
             echo "Available directories in recipes/:"
-            ls -la recipes/ || echo "No recipes directory found"
+            ls -lah recipes/ || echo "No recipes directory found"
             exit 1
           fi
 
-          echo "✅ Found codemod directory: $CODEMOD_PATH"
+          echo "✓ Found codemod directory: $CODEMOD_PATH"
           echo "Directory contents:"
-          ls -la "$CODEMOD_PATH"
+          ls -lah "$CODEMOD_PATH"
 
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -92,11 +92,11 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      # We don't use dev dependencies
+      # But we need npm to put local workspace in `node_modules`
+      # so codemod can bundle workspaces in the codemod tarball correctly
       - name: Install project dependencies
         run: npm ci
-
-      - name: Install Codemod CLI
-        run: npm install -g codemod@next
 
       # Run test before login to not waste time if it fails
       - name: Run codemod Tests
@@ -106,11 +106,11 @@ jobs:
       - name: Authenticate with Codemod registry
         env:
           CODEMOD_TOKEN: ${{ secrets.CODEMOD_TOKEN }}
-        run: codemod login --token "$CODEMOD_TOKEN"
+        run: npx codemod@next login --token "$CODEMOD_TOKEN"
 
       - name: Publish codemod
         working-directory: ${{ steps.parse-tag.outputs.codemod-path }}
-        run: codemod publish
+        run: npx codemod@next publish
 
       - name: Create release summary
         env:

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -1,107 +1,82 @@
-name: Codemod publish
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# For more information see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
+
+name: Publish Codemod
 
 on:
-  workflow_dispatch:
   push:
-    paths:
-      - "recipes/**"
-    branches:
-      - main
-
-permissions:
-  contents: read
+    tags:
+      - 'v*@*'  # Match tags like v1.0.0@my-codemod
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v1.0.0@my-codemod)'
+        required: true
+        type: string
 
 jobs:
-  paths-filter:
-    permissions:
-      contents: read
-      pull-requests: read
-    name: Check for .codemodrc.json files changes
-    runs-on: ubuntu-latest
-    outputs:
-      codemods: ${{ steps.filter.outputs.codemods }}
-      codemods_files: ${{ steps.filter.outputs.codemods_files }}
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
-        id: filter
-        name: Filter codemods
-        with:
-          list-files: json
-          filters: |
-            codemods:
-              - '**/.codemodrc.json'
-
-  prepare-matrix:
-    name: Prepare matrix
-    runs-on: ubuntu-latest
-    needs: paths-filter
-    if: always() && needs.paths-filter.outputs.codemods == 'true'
-    outputs:
-      codemod_files: ${{ steps.set-matrix.outputs.codemod_files }}
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49
-        with:
-          egress-policy: audit
-
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-
-      - name: Set matrix for codemods
-        id: set-matrix
-        run: |
-          FILES_JSON=$(echo '${{ needs.paths-filter.outputs.codemods_files }}' | jq -c '{include: map({file: .})}')
-          echo "codemod_files=$FILES_JSON" >> "$GITHUB_OUTPUT"
-          echo "Matrix JSON: $FILES_JSON"
-
   publish:
-    name: Publish ${{ matrix.file }}
     runs-on: ubuntu-latest
-    needs: prepare-matrix
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.codemod_files)}}
-    env:
-      CODEMOD_API_KEY: ${{ secrets.CODEMOD_API_KEY }}
+
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49
-        with:
-          egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
+      - name: Extract version and codemod name
+        id: extract
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+          # Extract version (everything before @)
+          VERSION="${TAG%@*}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix
+
+          # Extract codemod name (everything after @)
+          CODEMOD_NAME="${TAG#*@}"
+
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "CODEMOD_NAME=$CODEMOD_NAME" >> $GITHUB_OUTPUT
+          echo "CODEMOD_PATH=recipes/$CODEMOD_NAME" >> $GITHUB_OUTPUT
+
+          echo "Publishing: $CODEMOD_NAME (version: $VERSION) from recipes/$CODEMOD_NAME"
+
+      - name: Validate codemod directory exists
+        run: |
+          if [ ! -d "${{ steps.extract.outputs.CODEMOD_PATH }}" ]; then
+            echo "Error: Directory ${{ steps.extract.outputs.CODEMOD_PATH }} does not exist"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          sudo apt-get install libsecret-1-dev
-          npm install -g codemod
+        run: npm ci
 
-      - name: Test codemod
-        run: |
-          DIR=$(dirname "${{ matrix.file }}")
-          echo "Testing codemod in: $DIR"
-          cd "$DIR"
-          npm install
-          npm run --if-present test
+      - name: Install Codemod CLI
+        run: npm install -g codemod@next
+
+      - name: Login to Codemod registry
+        env:
+          CODEMOD_TOKEN: ${{ secrets.CODEMOD_TOKEN }}
+        run: codemod login --token "$CODEMOD_TOKEN"
+
+      - name: Run test
+        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
+        run: node --run test
+
+      - name: Publish codemod (dry run)
+        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
+        run: codemod publish --dry-run
 
       - name: Publish codemod
-        run: |
-          DIR=$(dirname "${{ matrix.file }}")
-          echo "Publishing codemod in: $DIR"
-          cd "$DIR"
-          npx codemod publish
+        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
+        run: codemod publish

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -1,18 +1,19 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# For more information see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
+
 name: Publish Codemod
 
 on:
   push:
     tags:
-      - "v*@*"
+      - "v*@*" # eg: v1.0.0@codemod-name
   workflow_dispatch:
     inputs:
       tag:
         description: "Tag to publish (format: v1.0.0@codemod-name)"
         required: true
         type: string
-
-env:
-  NODE_VERSION_FILE: ".nvmrc"
 
 jobs:
   validate-and-publish:
@@ -87,7 +88,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: ${{ env.NODE_VERSION_FILE }}
+          node-version-file: ".nvmrc"
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -97,8 +98,9 @@ jobs:
       - name: Install Codemod CLI
         run: npm install -g codemod@next
 
+      # Run test before login to not waste time if it fails
       - name: Run codemod Tests
-        working-directory: Test``
+        working-directory: ${{ steps.parse-tag.outputs.codemod-path }}
         run: node --test
 
       - name: Authenticate with Codemod registry

--- a/.github/workflows/codemod_publish.yml
+++ b/.github/workflows/codemod_publish.yml
@@ -1,83 +1,130 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-
-# For more information see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
-
 name: Publish Codemod
 
 on:
   push:
     tags:
-      - 'v*@*'  # Match tags like v1.0.0@my-codemod
+      - "v*@*"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g., v1.0.0@my-codemod)'
+        description: "Tag to publish (format: v1.0.0@codemod-name)"
         required: true
         type: string
 
+env:
+  NODE_VERSION_FILE: ".nvmrc"
+
 jobs:
-  publish:
+  validate-and-publish:
+    name: Validate and Publish Codemod
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    outputs:
+      version: ${{ steps.parse-tag.outputs.version }}
+      codemod-name: ${{ steps.parse-tag.outputs.codemod-name }}
+      codemod-path: ${{ steps.parse-tag.outputs.codemod-path }}
 
-      - name: Extract version and codemod name
-        id: extract
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Parse tag and extract metadata
+        id: parse-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          # Determine the tag based on trigger type
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            TAG="$INPUT_TAG"
+            echo "Using manually provided tag: $TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
+            echo "Using pushed tag: $TAG"
           fi
 
-          # Extract version (everything before @)
-          VERSION="${TAG%@*}"
-          VERSION="${VERSION#v}"  # Remove 'v' prefix
-
-          # Extract codemod name (everything after @)
-          CODEMOD_NAME="${TAG#*@}"
-
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "CODEMOD_NAME=$CODEMOD_NAME" >> $GITHUB_OUTPUT
-          echo "CODEMOD_PATH=recipes/$CODEMOD_NAME" >> $GITHUB_OUTPUT
-
-          echo "Publishing version $VERSION of $CODEMOD_NAME from recipes/$CODEMOD_NAME"
-
-      - name: Validate codemod directory exists
-        run: |
-          if [ ! -d "${{ steps.extract.outputs.CODEMOD_PATH }}" ]; then
-            echo "Error: Directory ${{ steps.extract.outputs.CODEMOD_PATH }} does not exist"
+          # Validate tag format
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+@[a-zA-Z0-9_-]+$ ]]; then
+            echo "❌ Invalid tag format: $TAG"
+            echo "Expected format: v1.0.0@codemod-name"
             exit 1
           fi
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: 'npm'
+          # Extract components
+          VERSION="${TAG%@*}"      # Everything before @
+          VERSION="${VERSION#v}"   # Remove v prefix
+          CODEMOD_NAME="${TAG#*@}" # Everything after @
+          CODEMOD_PATH="recipes/$CODEMOD_NAME"
 
-      - name: Install dependencies
+          # Set outputs
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "codemod-name=$CODEMOD_NAME" >> $GITHUB_OUTPUT
+          echo "codemod-path=$CODEMOD_PATH" >> $GITHUB_OUTPUT
+
+      - name: Verify codemod directory
+        env:
+          CODEMOD_PATH: ${{ steps.parse-tag.outputs.codemod-path }}
+        run: |
+          if [[ ! -d "$CODEMOD_PATH" ]]; then
+            echo "❌ Codemod directory not found: $CODEMOD_PATH"
+            echo "Available directories in recipes/:"
+            ls -la recipes/ || echo "No recipes directory found"
+            exit 1
+          fi
+
+          echo "✅ Found codemod directory: $CODEMOD_PATH"
+          echo "Directory contents:"
+          ls -la "$CODEMOD_PATH"
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: ${{ env.NODE_VERSION_FILE }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install project dependencies
         run: npm ci
 
       - name: Install Codemod CLI
         run: npm install -g codemod@next
 
-      # Run test first so if it's failing, we don't waste time to login and rest of thing
-      - name: Run test
-        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
-        run: node --run test
+      - name: Run codemod Tests
+        working-directory: Test``
+        run: node --test
 
-      - name: Login to Codemod registry
+      - name: Authenticate with Codemod registry
         env:
           CODEMOD_TOKEN: ${{ secrets.CODEMOD_TOKEN }}
         run: codemod login --token "$CODEMOD_TOKEN"
 
-      - name: Publish codemod (dry run)
-        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
-        run: codemod publish --dry-run
-
       - name: Publish codemod
-        working-directory: ${{ steps.extract.outputs.CODEMOD_PATH }}
+        working-directory: ${{ steps.parse-tag.outputs.codemod-path }}
         run: codemod publish
+
+      - name: Create release summary
+        env:
+          CODEMOD_NAME: ${{ steps.parse-tag.outputs.codemod-name }}
+          VERSION: ${{ steps.parse-tag.outputs.version }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          TRIGGER: ${{ github.event_name == 'workflow_dispatch' && 'Manual' || 'Tag Push' }}
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          # 🚀 Codemod Publication Summary
+
+          **Codemod:** \`$CODEMOD_NAME\`
+          **Version:** \`$VERSION\`
+          **Tag:** \`$TAG\`
+          **Trigger:** $TRIGGER by $ACTOR
+
+          ✅ Codemod has been successfully published to the registry!
+          EOF


### PR DESCRIPTION
## Description 

introduce new ci for releasing codemod based on git tag

Also not that `correct-ts-specifiers` will not be anymore publish using GHA since it's use legacy codemod.

## Related issue 

Close #108 