### PR TITLE
refactor(workflows): add workflow schema to `workflow.yaml`s and fix the step title for rmdir

### DIFF
--- a/recipes/create-require-from-path/workflow.yaml
+++ b/recipes/create-require-from-path/workflow.yaml
@@ -1,10 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
 version: "1"
 nodes:
   - id: apply-transforms
     name: Apply AST Transformations
     type: automatic
-    runtime:
-      type: direct
     steps:
       - name: Handle DEP0130 via transforming `createRequireFromPath` to `createRequire`.
         js-ast-grep:

--- a/recipes/import-assertions-to-attributes/workflow.yaml
+++ b/recipes/import-assertions-to-attributes/workflow.yaml
@@ -1,10 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
 version: "1"
 nodes:
   - id: apply-transforms
     name: Apply AST Transformations
     type: automatic
-    runtime:
-      type: direct
     steps:
       - name: Replace `assert` import attribute to the `with` ECMAScript import attribute.
         js-ast-grep:

--- a/recipes/process-main-module/workflow.yaml
+++ b/recipes/process-main-module/workflow.yaml
@@ -1,11 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
 version: "1"
 
 nodes:
   - id: apply-transforms
     name: Apply AST Transformations
     type: automatic
-    runtime:
-      type: direct
     steps:
       - name: Handle DEP0138 via transforming `process.mainModule` to `require.main`.
         js-ast-grep:

--- a/recipes/rmdir/workflow.yaml
+++ b/recipes/rmdir/workflow.yaml
@@ -1,13 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
 version: "1"
 
 nodes:
   - id: apply-transforms
     name: Apply AST Transformations
     type: automatic
-    runtime:
-      type: direct
     steps:
-      - name: Replace `assert` import attribute to the `with` ECMAScript import attribute.
+      - name: Handle DEP0147 via transforming `fs.rmdir` to `fs.rm`.
         js-ast-grep:
           js_file: src/workflow.ts
           base_path: .

--- a/recipes/tmpdir-to-tmpdir/workflow.yaml
+++ b/recipes/tmpdir-to-tmpdir/workflow.yaml
@@ -1,11 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
 version: "1"
 
 nodes:
   - id: apply-transforms
     name: Apply AST Transformations
     type: automatic
-    runtime:
-      type: direct
     steps:
       - name: Handle DEP0022 via transforming `tmpDir` to `tmpdir`.
         js-ast-grep:


### PR DESCRIPTION
- Added JSON schema validation to the workflow yaml files
- Removed `runtime: direct` as it's the default and always will be.
- Fixed the `rmdir` codemod's step title