### PR TITLE
feat(crypto): add RSA-PSS codemod for DEP0154

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,6 +1410,10 @@
       "resolved": "recipes/create-require-from-path",
       "link": true
     },
+    "node_modules/@nodejs/crypto-rsa-pss-update": {
+      "resolved": "recipes/crypto-rsa-pss-update",
+      "link": true
+    },
     "node_modules/@nodejs/import-assertions-to-attributes": {
       "resolved": "recipes/import-assertions-to-attributes",
       "link": true
@@ -4063,6 +4067,18 @@
         "@types/node": "^24.0.3"
       }
     },
+    "recipes/crypto-rsa-pss-update": {
+      "name": "@nodejs/crypto-rsa-pss-update",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nodejs/codemod-utils": "*"
+      },
+      "devDependencies": {
+        "@codemod.com/jssg-types": "^1.0.3",
+        "@types/node": "^24.0.3"
+      }
+    },
     "recipes/import-assertions-to-attributes": {
       "name": "@nodejs/import-assertions-to-attributes",
       "version": "1.0.0",
@@ -4074,7 +4090,7 @@
     },
     "recipes/process-main-module": {
       "name": "@nodejs/process-main-module",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@nodejs/codemod-utils": "0.0.0"

--- a/recipes/crypto-rsa-pss-update/README.md
+++ b/recipes/crypto-rsa-pss-update/README.md
@@ -1,0 +1,67 @@
+# crypto-rsa-pss-update
+
+Codemod to handle Node.js crypto deprecation DEP0154 by transforming deprecated RSA-PSS key generation options.
+
+## What it does
+
+This codemod transforms deprecated RSA-PSS crypto options in `crypto.generateKeyPair()` and `crypto.generateKeyPairSync()` calls:
+
+- `hash` → `hashAlgorithm`
+- `mgf1Hash` → `mgf1HashAlgorithm`
+
+The transformation only applies to calls with `'rsa-pss'` as the key type.
+
+## Examples
+
+### Before
+
+```javascript
+const crypto = require('crypto');
+
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256',
+  mgf1Hash: 'sha1',
+  saltLength: 32
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+crypto.generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256'
+});
+```
+
+### After
+
+```javascript
+const crypto = require('crypto');
+
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256',
+  mgf1HashAlgorithm: 'sha1',
+  saltLength: 32
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+crypto.generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256'
+});
+```
+
+## Usage
+
+```bash
+npx codemod@next @nodejs/crypto-rsa-pss-update
+```
+
+## Supports
+
+- Both `crypto.generateKeyPair()` and `crypto.generateKeyPairSync()`
+- Destructured imports: `const { generateKeyPair } = require('crypto')`
+- Only transforms `'rsa-pss'` key type calls
+- Preserves all other options and call structure

--- a/recipes/crypto-rsa-pss-update/codemod.yaml
+++ b/recipes/crypto-rsa-pss-update/codemod.yaml
@@ -1,0 +1,23 @@
+schema_version: "1.0"
+name: "@nodejs/crypto-rsa-pss-update"
+version: 1.0.0
+description: Handle DEP0154 via transforming deprecated RSA-PSS crypto options `hash` to `hashAlgorithm` and `mgf1Hash` to `mgf1HashAlgorithm`
+author: Claude Code
+license: MIT
+workflow: workflow.yaml
+category: migration
+
+targets:
+  languages:
+    - javascript
+    - typescript
+
+keywords:
+  - transformation
+  - migration
+  - crypto
+  - rsa-pss
+
+registry:
+  access: public
+  visibility: public

--- a/recipes/crypto-rsa-pss-update/codemod.yaml
+++ b/recipes/crypto-rsa-pss-update/codemod.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 name: "@nodejs/crypto-rsa-pss-update"
 version: 1.0.0
 description: Handle DEP0154 via transforming deprecated RSA-PSS crypto options `hash` to `hashAlgorithm` and `mgf1Hash` to `mgf1HashAlgorithm`
-author: Claude Code
+author: Mauro Nievas
 license: MIT
 workflow: workflow.yaml
 category: migration

--- a/recipes/crypto-rsa-pss-update/package.json
+++ b/recipes/crypto-rsa-pss-update/package.json
@@ -12,7 +12,7 @@
     "directory": "recipes/crypto-rsa-pss-update",
     "bugs": "https://github.com/nodejs/userland-migrations/issues"
   },
-  "author": "Claude Code",
+  "author": "Mauro Nievas",
   "license": "MIT",
   "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/crypto-rsa-pss-update/README.md",
   "devDependencies": {

--- a/recipes/crypto-rsa-pss-update/package.json
+++ b/recipes/crypto-rsa-pss-update/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nodejs/crypto-rsa-pss-update",
+  "version": "1.0.0",
+  "description": "Handle DEP0154 via transforming deprecated RSA-PSS crypto options `hash` to `hashAlgorithm` and `mgf1Hash` to `mgf1HashAlgorithm`.",
+  "type": "module",
+  "scripts": {
+    "test": "npx codemod@next jssg test -l typescript ./src/workflow.ts ./"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/userland-migrations.git",
+    "directory": "recipes/crypto-rsa-pss-update",
+    "bugs": "https://github.com/nodejs/userland-migrations/issues"
+  },
+  "author": "Claude Code",
+  "license": "MIT",
+  "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/crypto-rsa-pss-update/README.md",
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "@codemod.com/jssg-types": "^1.0.3"
+  },
+  "dependencies": {
+    "@nodejs/codemod-utils": "*"
+  }
+}

--- a/recipes/crypto-rsa-pss-update/src/workflow.ts
+++ b/recipes/crypto-rsa-pss-update/src/workflow.ts
@@ -1,0 +1,83 @@
+import type { SgRoot, Edit } from "@codemod.com/jssg-types/main";
+
+/**
+ * Transform function that updates deprecated RSA-PSS crypto options.
+ * 
+ * Transforms:
+ * - hash -> hashAlgorithm
+ * - mgf1Hash -> mgf1HashAlgorithm
+ * 
+ * Only applies to crypto.generateKeyPair() and crypto.generateKeyPairSync() 
+ * calls with 'rsa-pss' as the first argument.
+ */
+export default function transform(root: SgRoot): string | null {
+	const rootNode = root.root();
+	let hasChanges = false;
+	const edits: Edit[] = [];
+
+	// Find all generateKeyPair and generateKeyPairSync calls
+	const generateKeyPairCalls = rootNode.findAll({
+		rule: {
+			any: [
+				{ pattern: "crypto.generateKeyPair($TYPE, $OPTIONS, $CALLBACK)" },
+				{ pattern: "crypto.generateKeyPair($TYPE, $OPTIONS)" },
+				{ pattern: "generateKeyPair($TYPE, $OPTIONS, $CALLBACK)" },
+				{ pattern: "generateKeyPair($TYPE, $OPTIONS)" }
+			]
+		}
+	});
+
+	const generateKeyPairSyncCalls = rootNode.findAll({
+		rule: {
+			any: [
+				{ pattern: "crypto.generateKeyPairSync($TYPE, $OPTIONS)" },
+				{ pattern: "generateKeyPairSync($TYPE, $OPTIONS)" }
+			]
+		}
+	});
+
+	// Process both generateKeyPair and generateKeyPairSync calls
+	const allCalls = [...generateKeyPairCalls, ...generateKeyPairSyncCalls];
+
+	for (const call of allCalls) {
+		const typeMatch = call.getMatch("TYPE");
+		const optionsMatch = call.getMatch("OPTIONS");
+
+		if (!typeMatch || !optionsMatch) continue;
+
+		// Only process 'rsa-pss' key type
+		const typeText = typeMatch.text();
+		if (!typeText.includes("'rsa-pss'") && !typeText.includes('"rsa-pss"')) {
+			continue;
+		}
+
+		const optionsText = optionsMatch.text();
+		let newOptionsText = optionsText;
+		let optionsChanged = false;
+
+		// Transform hash -> hashAlgorithm
+		if (optionsText.includes("hash:")) {
+			// Match hash: followed by value, but not hashAlgorithm:
+			newOptionsText = newOptionsText.replace(/\bhash:\s*/g, "hashAlgorithm: ");
+			optionsChanged = true;
+		}
+
+		// Transform mgf1Hash -> mgf1HashAlgorithm
+		if (optionsText.includes("mgf1Hash:")) {
+			newOptionsText = newOptionsText.replace(/\bmgf1Hash:\s*/g, "mgf1HashAlgorithm: ");
+			optionsChanged = true;
+		}
+
+		if (optionsChanged) {
+			// Replace the entire call with updated options
+			const callText = call.text();
+			const newCallText = callText.replace(optionsText, newOptionsText);
+			edits.push(call.replace(newCallText));
+			hasChanges = true;
+		}
+	}
+
+	if (!hasChanges) return null;
+
+	return rootNode.commitEdits(edits);
+}

--- a/recipes/crypto-rsa-pss-update/tests/expected/basic.js
+++ b/recipes/crypto-rsa-pss-update/tests/expected/basic.js
@@ -1,0 +1,24 @@
+const crypto = require('crypto');
+
+// Basic case with hash option
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256',
+  saltLength: 32
+}, (err, publicKey, privateKey) => {
+  console.log('Generated keys');
+});
+
+// Basic case with mgf1Hash option
+crypto.generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  mgf1HashAlgorithm: 'sha256'
+});
+
+// Both options together
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256',
+  mgf1HashAlgorithm: 'sha1',
+  saltLength: 32
+});

--- a/recipes/crypto-rsa-pss-update/tests/expected/destructured.js
+++ b/recipes/crypto-rsa-pss-update/tests/expected/destructured.js
@@ -1,0 +1,15 @@
+const { generateKeyPair, generateKeyPairSync } = require('crypto');
+
+// Destructured import with hash option
+generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256'
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+// Destructured sync version
+generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  mgf1HashAlgorithm: 'sha1'
+});

--- a/recipes/crypto-rsa-pss-update/tests/expected/non-rsa-pss.js
+++ b/recipes/crypto-rsa-pss-update/tests/expected/non-rsa-pss.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+
+// Should NOT be transformed - different key type
+crypto.generateKeyPair('rsa', {
+  modulusLength: 2048,
+  hash: 'sha256'
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+// Should NOT be transformed - ed25519
+crypto.generateKeyPairSync('ed25519', {
+  hash: 'sha256'
+});
+
+// Should be transformed - rsa-pss
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hashAlgorithm: 'sha256'
+});

--- a/recipes/crypto-rsa-pss-update/tests/input/basic.js
+++ b/recipes/crypto-rsa-pss-update/tests/input/basic.js
@@ -1,0 +1,24 @@
+const crypto = require('crypto');
+
+// Basic case with hash option
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256',
+  saltLength: 32
+}, (err, publicKey, privateKey) => {
+  console.log('Generated keys');
+});
+
+// Basic case with mgf1Hash option
+crypto.generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  mgf1Hash: 'sha256'
+});
+
+// Both options together
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256',
+  mgf1Hash: 'sha1',
+  saltLength: 32
+});

--- a/recipes/crypto-rsa-pss-update/tests/input/destructured.js
+++ b/recipes/crypto-rsa-pss-update/tests/input/destructured.js
@@ -1,0 +1,15 @@
+const { generateKeyPair, generateKeyPairSync } = require('crypto');
+
+// Destructured import with hash option
+generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256'
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+// Destructured sync version
+generateKeyPairSync('rsa-pss', {
+  modulusLength: 2048,
+  mgf1Hash: 'sha1'
+});

--- a/recipes/crypto-rsa-pss-update/tests/input/non-rsa-pss.js
+++ b/recipes/crypto-rsa-pss-update/tests/input/non-rsa-pss.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+
+// Should NOT be transformed - different key type
+crypto.generateKeyPair('rsa', {
+  modulusLength: 2048,
+  hash: 'sha256'
+}, (err, publicKey, privateKey) => {
+  // callback
+});
+
+// Should NOT be transformed - ed25519
+crypto.generateKeyPairSync('ed25519', {
+  hash: 'sha256'
+});
+
+// Should be transformed - rsa-pss
+crypto.generateKeyPair('rsa-pss', {
+  modulusLength: 2048,
+  hash: 'sha256'
+});

--- a/recipes/crypto-rsa-pss-update/workflow.yaml
+++ b/recipes/crypto-rsa-pss-update/workflow.yaml
@@ -1,0 +1,25 @@
+version: "1"
+
+nodes:
+  - id: apply-transforms
+    name: Apply AST Transformations
+    type: automatic
+    runtime:
+      type: direct
+    steps:
+      - name: Replace deprecated RSA-PSS crypto options `hash` to `hashAlgorithm` and `mgf1Hash` to `mgf1HashAlgorithm`.
+        js-ast-grep:
+          js_file: src/workflow.ts
+          base_path: .
+          include:
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.mjs"
+            - "**/*.cjs"
+            - "**/*.cts"
+            - "**/*.mts"
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript


### PR DESCRIPTION
 ## Summary
  Add codemod to transform deprecated RSA-PSS crypto options:
  - `hash` → `hashAlgorithm`
  - `mgf1Hash` → `mgf1HashAlgorithm`

  ## Changes
  - Only transforms `crypto.generateKeyPair()` and `crypto.generateKeyPairSync()` calls with `'rsa-pss'` key type
  - Supports both direct calls (`crypto.generateKeyPair`) and destructured imports (`generateKeyPair`)
  - Comprehensive test coverage for various usage patterns

  ## Test plan
  - [x] Tests pass for basic transformations
  - [x] Tests pass for destructured imports
  - [x] Tests verify non-rsa-pss calls are ignored
  - [x] Lint and type checks pass

Resolves #144 