### PR TITLE
fix(getNodeRequireCalls-utility): detect member_expression statements

### DIFF
--- a/recipes/correct-ts-specifiers/src/fixtures/e2e/test.ts
+++ b/recipes/correct-ts-specifiers/src/fixtures/e2e/test.ts
@@ -3,17 +3,17 @@ import { URL } from 'node:url';
 import { bar } from '@dep/bar';
 import { foo } from 'foo';
 
-import { Bird } from './Bird';
+import { Bird } from './Bird/index.ts';
 import { Cat } from './Cat.ts';
-import { Dog } from '…/Dog/index.mjs';
+import { Dog } from '…/Dog/index.mts';
 import { baseUrl } from '#config.js';
-import { qux } from './qux.js';
+import { qux } from './qux.js/index.ts';
 
-export { Zed } from './zed';
+export type { Zed } from './zed.d.ts';
 
 // should.js be unchanged
 
-const nil = await import('./nil.js');
+const nil = await import('./nil.ts');
 
 const bird = new Bird('Tweety');
 const cat = new Cat('Milo');

--- a/recipes/correct-ts-specifiers/src/fixtures/e2e/test.ts
+++ b/recipes/correct-ts-specifiers/src/fixtures/e2e/test.ts
@@ -3,17 +3,17 @@ import { URL } from 'node:url';
 import { bar } from '@dep/bar';
 import { foo } from 'foo';
 
-import { Bird } from './Bird/index.ts';
+import { Bird } from './Bird';
 import { Cat } from './Cat.ts';
-import { Dog } from '…/Dog/index.mts';
+import { Dog } from '…/Dog/index.mjs';
 import { baseUrl } from '#config.js';
-import { qux } from './qux.js/index.ts';
+import { qux } from './qux.js';
 
-export type { Zed } from './zed.d.ts';
+export { Zed } from './zed';
 
 // should.js be unchanged
 
-const nil = await import('./nil.ts');
+const nil = await import('./nil.js');
 
 const bird = new Bird('Tweety');
 const cat = new Cat('Milo');

--- a/utils/src/ast-grep/require-call.test.ts
+++ b/utils/src/ast-grep/require-call.test.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert/strict";
+import assert from "node:assert/strict" ;
 import { describe, it } from "node:test";
 import astGrep from '@ast-grep/napi';
 import dedent from 'dedent';
@@ -13,6 +13,7 @@ describe("require-call", () => {
 		require("no:assignment");
 		require(variable);
 		require(\`backticks\`);
+		const cpus = require("node:os").cpus;
 	`;
 	const ast = astGrep.parse(astGrep.Lang.JavaScript, code);
 
@@ -33,5 +34,9 @@ describe("require-call", () => {
 		const utilRequires = getNodeRequireCalls(ast, 'util');
 		assert.strictEqual(utilRequires.length, 1);
 		assert.strictEqual(utilRequires[0].field('value')?.text(), 'require("node:util")');
+
+		const osRequires = getNodeRequireCalls(ast, "os");
+		assert.strictEqual(osRequires.length, 1);
+		assert.strictEqual(osRequires[0].field('value')?.text(), 'require("node:os").cpus');
 	});
 });

--- a/utils/src/ast-grep/require-call.test.ts
+++ b/utils/src/ast-grep/require-call.test.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert/strict" ;
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import astGrep from '@ast-grep/napi';
 import dedent from 'dedent';

--- a/utils/src/ast-grep/require-call.ts
+++ b/utils/src/ast-grep/require-call.ts
@@ -25,24 +25,58 @@ export const getNodeRequireCalls = (rootNode: SgRoot, nodeModuleName: string): S
 					{
 						has: {
 							field: "value",
-							kind: "call_expression",
-							all: [
+							any: [
 								{
-									has: {
-										field: "function",
-										kind: "identifier",
-										regex: "^require$"
-									}
+									kind: "call_expression",
+									all: [
+										{
+											has: {
+												field: "function",
+												kind: "identifier",
+												regex: "^require$"
+											}
+										},
+										{
+											has: {
+												field: "arguments",
+												kind: "arguments",
+												has: {
+													kind: "string",
+													regex: `^['"](node:)?${nodeModuleName}['"]$`
+												}
+											}
+										}
+									]
 								},
 								{
-									has: {
-										field: "arguments",
-										kind: "arguments",
-										has: {
-											kind: "string",
-											regex: `^['"](node:)?${nodeModuleName}['"]$`
+									kind: "member_expression",
+									all: [
+										{
+											has: {
+												field: "object",
+												kind: "call_expression",
+												all: [
+												{
+													has: {
+														field: "function",
+														kind: "identifier",
+														regex: "^require$"
+													}
+												},
+												{
+													has: {
+														field: "arguments",
+														kind: "arguments",
+														has: {
+															kind: "string",
+															regex: `^['"](node:)?${nodeModuleName}['"]$`
+														}
+													}
+												}
+												]
+											}
 										}
-									}
+									]
 								}
 							]
 						}


### PR DESCRIPTION
Fixes #167 

As shown in the screenshot below, when a `call_expression` AST node is wrapped in an `expression_statement` , which occurs in require scenarios like `require('module').property` the `getNodeRequireCalls` utility fails to detect it. 

I’ve updated the utility to handle these cases.

<img height="450" alt="Screenshot from 2025-08-12 02-14-04" src="https://github.com/user-attachments/assets/b1144beb-6505-4b85-9c7a-5d616db09ca3" />


