### PR TITLE
feat(http-classes-with-new): add codemod for `node:http` classes instantiation with `new` keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,6 +1420,10 @@
       "resolved": "recipes/create-require-from-path",
       "link": true
     },
+    "node_modules/@nodejs/http-classes-with-new": {
+      "resolved": "recipes/http-classes-with-new",
+      "link": true
+    },
     "node_modules/@nodejs/import-assertions-to-attributes": {
       "resolved": "recipes/import-assertions-to-attributes",
       "link": true
@@ -4072,6 +4076,17 @@
         "@codemod.com/jssg-types": "^1.0.3"
       }
     },
+    "recipes/http-classes-with-new": {
+      "name": "@nodejs/http-classes-with-new",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nodejs/codemod-utils": "*"
+      },
+      "devDependencies": {
+        "@codemod.com/jssg-types": "^1.0.3"
+      }
+    },
     "recipes/import-assertions-to-attributes": {
       "name": "@nodejs/import-assertions-to-attributes",
       "version": "1.0.0",
@@ -4110,7 +4125,7 @@
         "@nodejs/codemod-utils": "*"
       },
       "devDependencies": {
-        "@types/node": "^24.2.1"
+        "@codemod.com/jssg-types": "^1.0.3"
       }
     },
     "utils": {
@@ -4119,6 +4134,7 @@
       "license": "MIT",
       "devDependencies": {
         "@ast-grep/napi": "^0.39.3",
+        "@codemod.com/jssg-types": "^1.0.3",
         "dedent": "^1.6.0"
       }
     }

--- a/recipes/http-classes-with-new/README.md
+++ b/recipes/http-classes-with-new/README.md
@@ -9,13 +9,12 @@ See [DEP0195](https://nodejs.org/api/deprecations.html#DEP0195).
 **Before:**
 
 ```js
-const http = require("node:http");
+// import { IncomingMessage, ClientRequest } from "node:http";
+// const http = require("node:http");
+
 const message = http.OutgoingMessage();
 const response = http.ServerResponse(socket);
-```
 
-```js
-import { IncomingMessage, ClientRequest } from "node:http";
 const incoming = IncomingMessage(socket);
 const request = ClientRequest(options);
 ```
@@ -23,13 +22,12 @@ const request = ClientRequest(options);
 **After:**
 
 ```js
-const http = require("node:http");
+// import { IncomingMessage, ClientRequest } from "node:http";
+// const http = require("node:http");
+
 const message = new http.OutgoingMessage();
 const response = new http.ServerResponse(socket);
-```
 
-```js
-import { IncomingMessage, ClientRequest } from "node:http";
 const incoming = new IncomingMessage(socket);
 const request = new ClientRequest(options);
 ```

--- a/recipes/http-classes-with-new/README.md
+++ b/recipes/http-classes-with-new/README.md
@@ -1,0 +1,35 @@
+# `http.request` DEP0195
+
+This recipe provides a guide for migrating from the deprecated `http.request` and its synchronous and promise-based counterparts to the new `http.request` method in Node.js.
+
+See [DEP0195](https://nodejs.org/api/deprecations.html#DEP0195).
+
+## Examples
+
+**Before:**
+
+```js
+const http = require("node:http");
+const message = http.OutgoingMessage();
+const response = http.ServerResponse(socket);
+```
+
+```js
+import { IncomingMessage, ClientRequest } from "node:http";
+const incoming = IncomingMessage(socket);
+const request = ClientRequest(options);
+```
+
+**After:**
+
+```js
+const http = require("node:http");
+const message = new http.OutgoingMessage();
+const response = new http.ServerResponse(socket);
+```
+
+```js
+import { IncomingMessage, ClientRequest } from "node:http";
+const incoming = new IncomingMessage(socket);
+const request = new ClientRequest(options);
+```

--- a/recipes/http-classes-with-new/codemod.yaml
+++ b/recipes/http-classes-with-new/codemod.yaml
@@ -1,7 +1,7 @@
 schema_version: "1.0"
 name: "@nodejs/http-classes-with-new"
 version: 1.0.0
-description: Handle DEDEP0195 Instantiating node:http classes without new
+description: "Handle DEDEP0195: Instantiating node:http classes without new"
 author: Usman S.
 license: MIT
 workflow: workflow.yaml

--- a/recipes/http-classes-with-new/codemod.yaml
+++ b/recipes/http-classes-with-new/codemod.yaml
@@ -1,0 +1,21 @@
+schema_version: "1.0"
+name: "@nodejs/http-classes-with-new"
+version: 1.0.0
+description: Handle DEDEP0195 Instantiating node:http classes without new
+author: Usman S.
+license: MIT
+workflow: workflow.yaml
+category: migration
+
+targets:
+  languages:
+    - javascript
+    - typescript
+
+keywords:
+  - transformation
+  - migration
+
+registry:
+  access: public
+  visibility: public

--- a/recipes/http-classes-with-new/package.json
+++ b/recipes/http-classes-with-new/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nodejs/http-classes-with-new",
+  "version": "1.0.0",
+  "description": "feat: handle DEP0195: Instantiating node:http classes without new.",
+  "type": "module",
+  "scripts": {
+    "test": "npx codemod jssg test -l typescript ./src/workflow.ts ./"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/userland-migrations.git",
+    "directory": "recipes/http-classes-with-new",
+    "bugs": "https://github.com/nodejs/userland-migrations/issues"
+  },
+  "author": "Usman S.",
+  "license": "MIT",
+  "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/http-classes-with-new/README.md",
+  "devDependencies": {
+    "@codemod.com/jssg-types": "^1.0.3"
+  },
+  "dependencies": {
+    "@nodejs/codemod-utils": "*"
+  }
+}

--- a/recipes/http-classes-with-new/package.json
+++ b/recipes/http-classes-with-new/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nodejs/http-classes-with-new",
   "version": "1.0.0",
-  "description": "feat: handle DEP0195: Instantiating node:http classes without new.",
+  "description": "Handle DEP0195: Instantiating node:http classes without new.",
   "type": "module",
   "scripts": {
     "test": "npx codemod jssg test -l typescript ./src/workflow.ts ./"

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -3,14 +3,17 @@ import { getNodeRequireCalls } from '@nodejs/codemod-utils/ast-grep/require-call
 import { resolveBindingPath } from '@nodejs/codemod-utils/ast-grep/resolve-binding-path';
 import type { SgRoot, Edit, SgNode } from '@codemod.com/jssg-types/main';
 
-const CLASS_NAMES = [
+/**
+ * Classes of the http module
+ */
+const CLASS_NAMES = Object.freeze([
 	'Agent',
 	'ClientRequest',
 	'IncomingMessage',
 	'OutgoingMessage',
 	'Server',
 	'ServerResponse',
-];
+]);
 
 /**
  * Transform function that converts deprecated node:http classes to use the `new` keyword
@@ -61,7 +64,7 @@ export default function transform(root: SgRoot): string | null {
  * @returns The base path of the http classes
  */
 function* getHttpClassBasePaths(statements: SgNode[]) {
-	for (const cls of classNames) {
+	for (const cls of CLASS_NAMES) {
 		for (const stmt of statements) {
 			const resolvedPath = resolveBindingPath(stmt, `$.${cls}`);
 			if (resolvedPath) {

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -1,0 +1,76 @@
+import { getNodeImportStatements } from "@nodejs/codemod-utils/ast-grep/import-statement";
+import { getNodeRequireCalls } from "@nodejs/codemod-utils/ast-grep/require-call";
+import { resolveBindingPath } from "@nodejs/codemod-utils/ast-grep/resolve-binding-path";
+import type { SgRoot, Edit, SgNode } from "@codemod.com/jssg-types/main";
+
+const classNames = [
+	"Agent",
+	"ClientRequest",
+	"IncomingMessage",
+	"OutgoingMessage",
+	"Server",
+	"ServerResponse",
+];
+
+/**
+ * Transform function that converts deprecated node:http classes to use the `new` keyword
+ *
+ * Handles:
+ * 1. http.Agent() -> new http.Agent()
+ * 2. http.ClientRequest() -> new http.ClientRequest()
+ * 3. http.IncomingMessage() -> new http.IncomingMessage()
+ * 4. http.OutgoingMessage() -> new http.OutgoingMessage()
+ * 5. http.Server() -> new http.Server()
+ * 6. http.ServerResponse() -> new http.ServerResponse()
+ */
+export default function transform(root: SgRoot): string | null {
+	const rootNode = root.root();
+	const edits: Edit[] = [];
+
+	const importNodes = getNodeImportStatements(root, "http");
+	const requireNodes = getNodeRequireCalls(root, "http");
+	const allStatementNodes = [...importNodes, ...requireNodes];
+	const classes = new Set<string>();
+
+	for (const basePath of getHttpClassBasePaths(allStatementNodes)) {
+		classes.add(basePath);
+	}
+
+	for (const cls of classes) {
+		const classesWithoutNew = rootNode.findAll({
+			rule: {
+				not: { follows: { pattern: "new" } },
+				any: [
+					{ pattern: `${cls}()` },
+					{ pattern: `${cls}($ARGS)` },
+					{ pattern: `${cls}($ARGS, $CALLBACK)` },
+				],
+			},
+		});
+
+		for (const clsWithoutNew of classesWithoutNew) {
+			edits.push(clsWithoutNew.replace(`new ${clsWithoutNew.text()}`));
+		}
+	}
+
+	if (edits.length === 0) return null;
+
+	return rootNode.commitEdits(edits);
+}
+
+/**
+ * Get the base path of the http classes
+ *
+ * @param statements - The import & require statements to search for the http classes
+ * @returns The base path of the http classes
+ */
+function* getHttpClassBasePaths(statements: SgNode[]) {
+	for (const cls of classNames) {
+		for (const stmt of statements) {
+			const resolvedPath = resolveBindingPath(stmt, `$.${cls}`);
+			if (resolvedPath) {
+				yield resolvedPath;
+			}
+		}
+	}
+}

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -6,14 +6,14 @@ import type { SgRoot, Edit, SgNode } from '@codemod.com/jssg-types/main';
 /**
  * Classes of the http module
  */
-const CLASS_NAMES = Object.freeze([
+const CLASS_NAMES = [
 	'Agent',
 	'ClientRequest',
 	'IncomingMessage',
 	'OutgoingMessage',
 	'Server',
 	'ServerResponse',
-]);
+];
 
 /**
  * Transform function that converts deprecated node:http classes to use the `new` keyword

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -39,10 +39,7 @@ export default function transform(root: SgRoot): string | null {
 		const classesWithoutNew = rootNode.findAll({
 			rule: {
 				not: { follows: { pattern: 'new' } },
-				any: [
-					{ pattern: `${cls}()` },
-					{ pattern: `${cls}($ARGS)` },
-					{ pattern: `${cls}($ARGS, $CALLBACK)` },
+        { pattern: `${cls}($$$ARGS)` },
 				],
 			},
 		});

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -16,12 +16,12 @@ const CLASS_NAMES = [
  * Transform function that converts deprecated node:http classes to use the `new` keyword
  *
  * Handles:
- * 1. http.Agent() -> new http.Agent()
- * 2. http.ClientRequest() -> new http.ClientRequest()
- * 3. http.IncomingMessage() -> new http.IncomingMessage()
- * 4. http.OutgoingMessage() -> new http.OutgoingMessage()
- * 5. http.Server() -> new http.Server()
- * 6. http.ServerResponse() -> new http.ServerResponse()
+ * 1. `http.Agent()` → `new http.Agent()`
+ * 2. `http.ClientRequest()` → `new http.ClientRequest()`
+ * 3. `http.IncomingMessage()` → `new http.IncomingMessage()`
+ * 4. `http.OutgoingMessage()` → `new http.OutgoingMessage()`
+ * 5. `http.Server()` → `new http.Server()`
+ * 6. `http.ServerResponse() → `new http.ServerResponse()`
  */
 export default function transform(root: SgRoot): string | null {
 	const rootNode = root.root();

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -39,8 +39,7 @@ export default function transform(root: SgRoot): string | null {
 		const classesWithoutNew = rootNode.findAll({
 			rule: {
 				not: { follows: { pattern: 'new' } },
-        { pattern: `${cls}($$$ARGS)` },
-				],
+				pattern: `${cls}($$$ARGS)`,
 			},
 		});
 

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -3,7 +3,7 @@ import { getNodeRequireCalls } from '@nodejs/codemod-utils/ast-grep/require-call
 import { resolveBindingPath } from '@nodejs/codemod-utils/ast-grep/resolve-binding-path';
 import type { SgRoot, Edit, SgNode } from '@codemod.com/jssg-types/main';
 
-const classNames = [
+const CLASS_NAMES = [
 	'Agent',
 	'ClientRequest',
 	'IncomingMessage',

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -1,15 +1,15 @@
-import { getNodeImportStatements } from "@nodejs/codemod-utils/ast-grep/import-statement";
-import { getNodeRequireCalls } from "@nodejs/codemod-utils/ast-grep/require-call";
-import { resolveBindingPath } from "@nodejs/codemod-utils/ast-grep/resolve-binding-path";
-import type { SgRoot, Edit, SgNode } from "@codemod.com/jssg-types/main";
+import { getNodeImportStatements } from '@nodejs/codemod-utils/ast-grep/import-statement';
+import { getNodeRequireCalls } from '@nodejs/codemod-utils/ast-grep/require-call';
+import { resolveBindingPath } from '@nodejs/codemod-utils/ast-grep/resolve-binding-path';
+import type { SgRoot, Edit, SgNode } from '@codemod.com/jssg-types/main';
 
 const classNames = [
-	"Agent",
-	"ClientRequest",
-	"IncomingMessage",
-	"OutgoingMessage",
-	"Server",
-	"ServerResponse",
+	'Agent',
+	'ClientRequest',
+	'IncomingMessage',
+	'OutgoingMessage',
+	'Server',
+	'ServerResponse',
 ];
 
 /**
@@ -27,8 +27,8 @@ export default function transform(root: SgRoot): string | null {
 	const rootNode = root.root();
 	const edits: Edit[] = [];
 
-	const importNodes = getNodeImportStatements(root, "http");
-	const requireNodes = getNodeRequireCalls(root, "http");
+	const importNodes = getNodeImportStatements(root, 'http');
+	const requireNodes = getNodeRequireCalls(root, 'http');
 	const allStatementNodes = [...importNodes, ...requireNodes];
 	const classes = new Set<string>();
 
@@ -39,7 +39,7 @@ export default function transform(root: SgRoot): string | null {
 	for (const cls of classes) {
 		const classesWithoutNew = rootNode.findAll({
 			rule: {
-				not: { follows: { pattern: "new" } },
+				not: { follows: { pattern: 'new' } },
 				any: [
 					{ pattern: `${cls}()` },
 					{ pattern: `${cls}($ARGS)` },

--- a/recipes/http-classes-with-new/src/workflow.ts
+++ b/recipes/http-classes-with-new/src/workflow.ts
@@ -30,11 +30,7 @@ export default function transform(root: SgRoot): string | null {
 	const importNodes = getNodeImportStatements(root, 'http');
 	const requireNodes = getNodeRequireCalls(root, 'http');
 	const allStatementNodes = [...importNodes, ...requireNodes];
-	const classes = new Set<string>();
-
-	for (const basePath of getHttpClassBasePaths(allStatementNodes)) {
-		classes.add(basePath);
-	}
+	const classes = new Set<string>(getHttpClassBasePaths(allStatementNodes));
 
 	for (const cls of classes) {
 		const classesWithoutNew = rootNode.findAll({

--- a/recipes/http-classes-with-new/tests/expected/file-1.js
+++ b/recipes/http-classes-with-new/tests/expected/file-1.js
@@ -1,0 +1,8 @@
+const http = require("node:http");
+
+const agent = new http.Agent();
+const request = new http.ClientRequest(options);
+const incoming = new http.IncomingMessage(socket);
+const message = new http.OutgoingMessage();
+const server = new http.Server();
+const response = new http.ServerResponse(socket);

--- a/recipes/http-classes-with-new/tests/expected/file-2.js
+++ b/recipes/http-classes-with-new/tests/expected/file-2.js
@@ -1,0 +1,15 @@
+import {
+	Agent,
+	ClientRequest,
+	IncomingMessage,
+	OutgoingMessage,
+	Server,
+	ServerResponse,
+} from "node:http";
+
+const agent = new Agent();
+const request = new ClientRequest(options);
+const incoming = new IncomingMessage(socket);
+const message = new OutgoingMessage();
+const server = new Server();
+const response = new ServerResponse(socket);

--- a/recipes/http-classes-with-new/tests/input/file-1.js
+++ b/recipes/http-classes-with-new/tests/input/file-1.js
@@ -1,0 +1,8 @@
+const http = require("node:http");
+
+const agent = http.Agent();
+const request = http.ClientRequest(options);
+const incoming = http.IncomingMessage(socket);
+const message = http.OutgoingMessage();
+const server = http.Server();
+const response = http.ServerResponse(socket);

--- a/recipes/http-classes-with-new/tests/input/file-2.js
+++ b/recipes/http-classes-with-new/tests/input/file-2.js
@@ -1,0 +1,15 @@
+import {
+	Agent,
+	ClientRequest,
+	IncomingMessage,
+	OutgoingMessage,
+	Server,
+	ServerResponse,
+} from "node:http";
+
+const agent = Agent();
+const request = ClientRequest(options);
+const incoming = IncomingMessage(socket);
+const message = OutgoingMessage();
+const server = Server();
+const response = ServerResponse(socket);

--- a/recipes/http-classes-with-new/tsconfig.json
+++ b/recipes/http-classes-with-new/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "alwaysStrict": true,
+    "baseUrl": "./",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "lib": ["ESNext", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noImplicitThis": true,
+    "removeComments": true,
+    "strict": true,
+    "stripInternal": true,
+    "target": "esnext"
+  },
+  "include": ["./"],
+  "exclude": [
+    "tests/**"
+  ]
+}

--- a/recipes/http-classes-with-new/workflow.yaml
+++ b/recipes/http-classes-with-new/workflow.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
+version: "1"
+
+nodes:
+  - id: apply-transforms
+    name: Apply AST Transformations
+    type: automatic
+    steps:
+      - name: Handle DEDEP0195 Instantiating node:http classes without new.
+        js-ast-grep:
+          js_file: src/workflow.ts
+          base_path: .
+          include:
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.mjs"
+            - "**/*.cjs"
+            - "**/*.cts"
+            - "**/*.mts"
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript


### PR DESCRIPTION
Closes #174 