### PR TITLE
chore(readme): update to include other exe methode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,23 @@ This repository contains codemods (automated migrations) for "userland" code. Th
 
 To run the transform scripts use [`codemod`](https://go.codemod.com/github) command below:
 
-```console
+### From registry
+
+With the codemod CLI you can run a workflow from the [Codemod Registry](https://codemod.link/nodejs-official). Replace `<recipe>` with the name of the recipe you want to run:
+
+```bash
 npx codemod @nodejs/<recipe>
+```
+
+### From source
+
+With the codemod CLI you can run a workflow from a local file. First, clone this repository, then run the command below from your project directory:
+
+```bash
+git clone https://github.com/nodejs/userland-migrations.git
+cd /path/to/your-project
+npx codemod workflow run -w /path/to/folder/userland-migrations/recipes/<recipe>/workflow.yaml
+
 ```
 
 See the [codemod CLI doc](https://go.codemod.com/cli-docs) for a full list of available commands.


### PR DESCRIPTION
Add a way to not depend of codemod registry. Because the cli will be always disponible on npm registry and our repo will also exist 