### PR TITLE
fix: handle property accesses cases on resolve-binding-path

### DIFF
--- a/utils/src/ast-grep/resolve-binding-path.test.ts
+++ b/utils/src/ast-grep/resolve-binding-path.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import astGrep from "@ast-grep/napi";
 import dedent from "dedent";
+import type Js from "@codemod.com/jssg-types/langs/javascript";
+import type { SgNode } from "@codemod.com/jssg-types/main";
 
 import { resolveBindingPath } from "./resolve-binding-path.ts";
 
@@ -12,7 +14,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "lexical_declaration",
 			},
@@ -29,7 +31,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -46,7 +48,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -63,7 +65,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -80,7 +82,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const functionDeclaration = rootNode.root().find({
+		const functionDeclaration = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "function_declaration",
 			},
@@ -95,7 +97,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "import_statement",
 			},
@@ -112,7 +114,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "import_statement",
 			},
@@ -129,7 +131,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "import_statement",
 			},
@@ -146,7 +148,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "import_statement",
 			},
@@ -163,7 +165,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -180,7 +182,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "lexical_declaration",
 			},
@@ -197,7 +199,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const importStatement = rootNode.root().find({
+		const importStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "import_statement",
 			},
@@ -214,7 +216,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -231,7 +233,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -248,7 +250,7 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -265,7 +267,8 @@ describe("resolve-binding-path", () => {
 		`;
 
 		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
-		const requireStatement = rootNode.root().find({
+
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
 			rule: {
 				kind: "variable_declarator",
 			},
@@ -274,5 +277,73 @@ describe("resolve-binding-path", () => {
 		const bindingPath = resolveBindingPath(requireStatement!, "$.types.isNativeError");
 
 		assert.strictEqual(bindingPath, "types.isNativeError");
+	});
+
+	it("should resolve correctly when have member-expression", () => {
+		const code = dedent`
+			const SlowBuffer = require('buffer').SlowBuffer;
+		`;
+
+		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
+			rule: {
+				kind: "variable_declarator",
+			},
+		});
+
+		const bindingPath = resolveBindingPath(requireStatement!, "$.SlowBuffer");
+
+		assert.strictEqual(bindingPath, "SlowBuffer");
+	});
+
+	it("should resolve correctly when there are multiple property accesses", () => {
+		const code = dedent`
+			const variable = require('buffer').a.b;
+		`;
+
+		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
+			rule: {
+				kind: "variable_declarator",
+			},
+		});
+
+		const bindingPath = resolveBindingPath(requireStatement!, "$.a.b");
+
+		assert.strictEqual(bindingPath, "variable");
+	});
+
+	it("should resolve correctly when there are multiple property accesses but not the entire path", () => {
+		const code = dedent`
+			const variable = require('buffer').a.b;
+		`;
+
+		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
+			rule: {
+				kind: "variable_declarator",
+			},
+		});
+
+		const bindingPath = resolveBindingPath(requireStatement!, "$.a.b.c.d.e");
+
+		assert.strictEqual(bindingPath, "variable.c.d.e");
+	});
+
+	it("should resolve correctly when there are multiple property accesses and destructuring", () => {
+		const code = dedent`
+			const { c: { d } } = require('buffer').a.b;
+		`;
+
+		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
+		const requireStatement = (rootNode.root() as SgNode<Js>).find({
+			rule: {
+				kind: "variable_declarator",
+			},
+		});
+
+		const bindingPath = resolveBindingPath(requireStatement!, "$.a.b.c.d.e");
+
+		assert.strictEqual(bindingPath, "d.e");
 	});
 });

--- a/utils/src/ast-grep/resolve-binding-path.ts
+++ b/utils/src/ast-grep/resolve-binding-path.ts
@@ -68,6 +68,31 @@ function resolveBindingPathRequire(node: SgNode<Js>, path: string) {
 		});
 	}
 
+	const propertyAccesses = activeNode.findAll({
+		rule: {
+			kind: "property_identifier",
+			inside: {
+				kind: "member_expression",
+			},
+		},
+	});
+
+	if (propertyAccesses.length) {
+		const pathArr = path.split(".");
+		let newPath = ["$"];
+		let i = 0;
+
+		for (; i < propertyAccesses.length; i++) {
+			// pathArr[i+1] to skip the first element (which is $) that was used for binding replacement
+			if (propertyAccesses[i]?.text() !== pathArr[i + 1]) {
+				return undefined;
+			}
+		}
+
+		// Get the remaining path that was not used in propertyAccesses
+		path = newPath.concat(pathArr.splice(i + 1)).join(".");
+	}
+
 	activeNode = activeNode.child(0);
 
 	if (activeNode?.kind() === "identifier") {


### PR DESCRIPTION
When a module is imported with property access after require

```js
const bind = require("module").a.b.c
const result = resolveBindingPath(node, "$.a.b.c")
```

It resolve as `bind.a.b.c` However, since the property is accessed immediately after **require**, it should instead resolve as `bind`, because the value of `c` is directly assigned to the bind constant.

This changes fixes that behavior.