### PR TITLE
fix: updateBinding when adding a new binding to an import node

### DIFF
--- a/utils/src/ast-grep/update-binding.test.ts
+++ b/utils/src/ast-grep/update-binding.test.ts
@@ -596,4 +596,33 @@ describe("update-binding", () => {
 
 		assert.strictEqual(sourceCode, `const { SlowBuffer, Buffer } = require("buffer");`);
 	});
+
+	it('When oldBinding is not passed, should create new binding in import', () => {
+		const code = dedent`
+			import { SlowBuffer } from 'buffer';
+		`;
+
+		const rootNode = astGrep.parse(astGrep.Lang.JavaScript, code);
+		const node = rootNode.root() as SgNode<Js>;
+
+		const requireStatement = node.find({
+			rule: {
+				kind: 'import_statement',
+			},
+		});
+
+		const change = updateBinding(requireStatement!, {
+			new: 'Buffer',
+		});
+
+		assert.notEqual(change, undefined);
+		assert.strictEqual(change?.lineToRemove, undefined);
+
+		const sourceCode = node.commitEdits([change?.edit!]);
+
+		assert.strictEqual(
+			sourceCode,
+			`import { SlowBuffer, Buffer } from 'buffer';`,
+		);
+	});
 });

--- a/utils/src/ast-grep/update-binding.ts
+++ b/utils/src/ast-grep/update-binding.ts
@@ -152,21 +152,6 @@ function handleNamedImportBindings(
 		},
 	});
 
-	for (const namedImport of namedImports) {
-		const text = namedImport.text();
-		if (text === options.old) {
-			if (!options?.new && namedImports.length === 1) {
-				return {
-					lineToRemove: node.range(),
-				};
-			}
-
-			return {
-				edit: updateObjectPattern(namedImports, options.old, options.new),
-			};
-		}
-	}
-
 	const aliasedImports = node.findAll({
 		rule: {
 			has: {
@@ -217,6 +202,17 @@ function handleNamedImportBindings(
 				};
 			}
 		}
+	}
+
+	if (namedImports.length !== 0) {
+		if (namedImports.length === 1 && !options?.new) {
+			return {
+				lineToRemove: node.range(),
+			};
+		}
+
+		const edit = updateObjectPattern(namedImports, options.old, options.new)
+		if(edit) return { edit }
 	}
 }
 
@@ -288,9 +284,8 @@ function handleNamedRequireBindings(
 		};
 	}
 
-	return {
-		edit: updateObjectPattern(declarations, options.old, options.new),
-	};
+	const edit = updateObjectPattern(declarations, options.old, options.new)
+	if(edit) return { edit }
 }
 
 function updateObjectPattern(
@@ -310,6 +305,8 @@ function updateObjectPattern(
 			break;
 		}
 	}
+
+	if(!parentNode) return
 
 	const bindings = parentNode.findAll({
 		rule: {


### PR DESCRIPTION
Fix an edge case where `updateBinding` was not able to add a new binding to `import_statement` nodes.