### PR TITLE
Fix util-log-to-console-log README

### DIFF
--- a/recipes/util-log-to-console-log/README.md
+++ b/recipes/util-log-to-console-log/README.md
@@ -1,6 +1,6 @@
 # `util.log` DEP0059
 
-This recipe transforms the usage of `log.util()` to use `console.log()`.
+This recipe transforms the usage of `util.log()` to use `console.log()`.
 
 See [DEP0059](https://nodejs.org/api/deprecations.html#DEP0059).
 


### PR DESCRIPTION
This recipe fixes usage of `util.log`, not `log.util` (which isn't even a thing in core Node.js).

Fixes: #257