### PR TITLE
docs(readme): add license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ You can find official Node.js codemods in the [Codemod Registry](https://codemod
 ## Acknowledgments
 
 We would like to extend our gratitude to the team at Codemod for providing their excellent tools and for their direct assistance with the Node.js project. Their support has been invaluable in making these migrations possible.
+
+## License
+
+This project is licensed under the [MIT](https://opensource.org/license/mit) license.


### PR DESCRIPTION
This PR adds a dedicated License section to the `README.md`, providing clear information about the project's licensing for contributors and users.