### PR TITLE
setup(workflow): forbid junk-drawer test organisation

### DIFF
--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -7,7 +7,7 @@ on:
     branches: ["*"]
     paths:
       - ".github/workflows/dir-organisation.yml"
-      - "recipes/**"
+      - "recipes/**/tests/**"
     types:
       - edited
       - opened

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Directory organisation
+
+on:
+  pull_request:
+    branches: [ "*" ]
+    paths:
+      - ".github/workflows/dir-organisation.yml"
+      - "recipes/**"
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+
+  forbid-junkdrawer-tests:
+    name: Test structure
+
+    runs-on: ubuntu-slim
+
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+
+    steps:
+      - run: >
+          junkdrawer=$(git diff --name-only main HEAD -- **/test/input **/test/expected)
+
+          if [[ -n "$junkdrawer" ]]; then
+            echo "❌ do not use junk-drawer tests directories; create a folder per test-case with an 'input' and an 'expected' file. Errant files:\n"
+            echo "$junkdrawer"
+            exit 1
+          fi

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -4,7 +4,7 @@ name: Directory organisation
 
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
     paths:
       - ".github/workflows/dir-organisation.yml"
       - "recipes/**"

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -39,7 +39,7 @@ jobs:
           show-progress: false
 
       - run: >
-          junkdrawer=$(git diff --name-only main HEAD -- **/test/input/** **/test/expected/**)
+          junkdrawer=$(git diff --name-only origin/HEAD HEAD -- **/test/input/** **/test/expected/**)
 
           if [[ -n "$junkdrawer" ]]; then
             echo "❌ do not use junk-drawer tests directories; create a folder per test-case with an 'input' and an 'expected' file. Errant files:\n"

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
-      # https://github.com/step-security/harden-runner/issues/627
+      # FIXME https://github.com/step-security/harden-runner/issues/627
       # - name: Harden the runner (Audit all outbound calls)
       #   uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       #   with:

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -27,6 +27,17 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
+      # https://github.com/step-security/harden-runner/issues/627
+      # - name: Harden the runner (Audit all outbound calls)
+      #   uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      #   with:
+      #     egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          show-progress: false
+
       - run: >
           junkdrawer=$(git diff --name-only main HEAD -- **/test/input/** **/test/expected/**)
 

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -39,7 +39,7 @@ jobs:
           show-progress: false
 
       - run: >
-          junkdrawer=$(git diff --name-only origin/HEAD HEAD -- **/test/input/** **/test/expected/**)
+          junkdrawer=$(git diff --name-only origin/main HEAD -- **/test/input/** **/test/expected/**)
 
           if [[ -n "$junkdrawer" ]]; then
             echo "❌ do not use junk-drawer tests directories; create a folder per test-case with an 'input' and an 'expected' file. Errant files:\n"

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           persist-credentials: false
           show-progress: false
+          fetch-depth: 0
 
       - run: >
           junkdrawer=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- **/test/input/** **/test/expected/**)

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -39,7 +39,7 @@ jobs:
           show-progress: false
 
       - run: >
-          junkdrawer=$(git diff --name-only origin/main HEAD -- **/test/input/** **/test/expected/**)
+          junkdrawer=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- **/test/input/** **/test/expected/**)
 
           if [[ -n "$junkdrawer" ]]; then
             echo "❌ do not use junk-drawer tests directories; create a folder per test-case with an 'input' and an 'expected' file. Errant files:\n"

--- a/.github/workflows/dir-organisation.yml
+++ b/.github/workflows/dir-organisation.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - run: >
-          junkdrawer=$(git diff --name-only main HEAD -- **/test/input **/test/expected)
+          junkdrawer=$(git diff --name-only main HEAD -- **/test/input/** **/test/expected/**)
 
           if [[ -n "$junkdrawer" ]]; then
             echo "❌ do not use junk-drawer tests directories; create a folder per test-case with an 'input' and an 'expected' file. Errant files:\n"


### PR DESCRIPTION
This check fails when a (non-draft) PR includes `**/test/input/**` and/or `**/test/expected/**`