### PR TITLE
setup(workflow): narrow `CI` path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - "recipes/**/*.ts"
       - "recipes/**/package.json"
       - "utils/**/*.ts"
-      - "utils/**/package.json"
+      - "utils/package.json"
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,20 @@ on:
   push:
     branches: ["*"]
     paths:
-      - "recipes/**"
-      - "utils/**"
+      - "recipes/**/*.ts"
+      - "recipes/**/package.json"
+      - "utils/**/*.ts"
+      - "utils/**/package.json"
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/ci.yml"
   pull_request:
     branches: ["*"]
     paths:
-      - "recipes/**"
-      - "utils/**"
+      - "recipes/**/*.ts"
+      - "recipes/**/package.json"
+      - "utils/**/*.ts"
+      - "utils/**/package.json"
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ on:
   push:
     branches: ["*"]
     paths:
+      - "recipes/**/*.js"
       - "recipes/**/*.ts"
       - "recipes/**/package.json"
+      - "utils/**/*.js"
       - "utils/**/*.ts"
       - "utils/package.json"
       - "package.json"
@@ -18,8 +20,10 @@ on:
   pull_request:
     branches: ["*"]
     paths:
+      - "recipes/**/*.js"
       - "recipes/**/*.ts"
       - "recipes/**/package.json"
+      - "utils/**/*.js"
       - "utils/**/*.ts"
       - "utils/**/package.json"
       - "package.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     name: Configure Node environment matrix
     runs-on: ubuntu-latest
 
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+
     outputs:
       latest: ${{ steps.set-matrix.outputs.requireds }}
     steps:


### PR DESCRIPTION
The `CI` workflow is concerned with implementation code (basically just typescript). We don't need to run linting, type-checking, and tests when non-code files change (ex markdown or yaml), and the yaml lint job is in a dedicated workflow now, so the `CI` job can filter just on js/ts and package.json files (where npm commands can change, affecting CI tasks).