### PR TITLE
feat(DEP0150): introduce `process-config-mutations-to-separate-config`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,6 +488,10 @@
       "resolved": "recipes/process-assert-to-node-assert",
       "link": true
     },
+    "node_modules/@nodejs/process-config-mutations-to-separate-config": {
+      "resolved": "recipes/process-config-mutations-to-separate-config",
+      "link": true
+    },
     "node_modules/@nodejs/process-main-module": {
       "resolved": "recipes/process-main-module",
       "link": true
@@ -913,6 +917,17 @@
     "recipes/process-assert-to-node-assert": {
       "name": "@nodejs/process-assert-to-node-assert",
       "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@nodejs/codemod-utils": "*"
+      },
+      "devDependencies": {
+        "@codemod.com/jssg-types": "^1.6.0"
+      }
+    },
+    "recipes/process-config-mutations-to-separate-config": {
+      "name": "@nodejs/process-config-mutations-to-separate-config",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@nodejs/codemod-utils": "*"

--- a/recipes/process-config-mutations-to-separate-config/README.md
+++ b/recipes/process-config-mutations-to-separate-config/README.md
@@ -1,0 +1,38 @@
+# DEP0150: `process.config` is now immutable
+
+Since Node.js v19, `process.config` is read-only. Any mutation throws at runtime.
+This recipe finds mutations and either rewrites them safely or comments them out
+with a hint to use a separate configuration object.
+
+See [DEP0150](https://nodejs.org/api/deprecations.html#DEP0150).
+
+## Examples
+
+Direct assignment is commented out with guidance:
+
+\`\`\`diff
+
+- process.config.target_defaults = { cflags: [] };
+
+* // process.config is now immutable and cannot be modified (DEP0150)
+* // Use a separate configuration object for custom values
+* // process.config.target_defaults = { cflags: [] };
+  \`\`\`
+
+`Object.assign` whose result is captured is rewritten in place, copying into a
+fresh object instead of mutating `process.config`:
+
+\`\`\`diff
+
+- const config = Object.assign(process.config, { custom: "settings" });
+
+* const config = Object.assign({}, process.config, { custom: "settings" });
+  \`\`\`
+
+Reading `process.config` is preserved unchanged.
+
+## Limitations
+
+Nested writes such as `console.log(process.config.foo = "bar")` are intentionally
+left untouched: rewriting them as line comments would create invalid JS, while
+the runtime error in Node.js v19+ already pinpoints the issue.

--- a/recipes/process-config-mutations-to-separate-config/README.md
+++ b/recipes/process-config-mutations-to-separate-config/README.md
@@ -10,24 +10,24 @@ See [DEP0150](https://nodejs.org/api/deprecations.html#DEP0150).
 
 Direct assignment is commented out with guidance:
 
-\`\`\`diff
+```diff
 
 - process.config.target_defaults = { cflags: [] };
 
 * // process.config is now immutable and cannot be modified (DEP0150)
 * // Use a separate configuration object for custom values
 * // process.config.target_defaults = { cflags: [] };
-  \`\`\`
+```
 
 `Object.assign` whose result is captured is rewritten in place, copying into a
 fresh object instead of mutating `process.config`:
 
-\`\`\`diff
+```diff
 
 - const config = Object.assign(process.config, { custom: "settings" });
 
 * const config = Object.assign({}, process.config, { custom: "settings" });
-  \`\`\`
+```
 
 Reading `process.config` is preserved unchanged.
 

--- a/recipes/process-config-mutations-to-separate-config/codemod.yaml
+++ b/recipes/process-config-mutations-to-separate-config/codemod.yaml
@@ -1,0 +1,23 @@
+schema_version: "1.0"
+name: "@nodejs/process-config-mutations-to-separate-config"
+version: "1.0.0"
+description: Handle DEP0150 by migrating or commenting out mutations to process.config.
+author: "Yijun Gao"
+license: MIT
+workflow: workflow.yaml
+category: migration
+
+targets:
+  languages:
+    - javascript
+    - typescript
+
+keywords:
+  - transformation
+  - migration
+  - process.config
+  - DEP0150
+
+registry:
+  access: public
+  visibility: public

--- a/recipes/process-config-mutations-to-separate-config/package.json
+++ b/recipes/process-config-mutations-to-separate-config/package.json
@@ -17,5 +17,8 @@
   "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/process-config-mutations-to-separate-config/README.md",
   "devDependencies": {
     "@codemod.com/jssg-types": "^1.6.0"
+  },
+  "dependencies": {
+    "@nodejs/codemod-utils": "*"
   }
 }

--- a/recipes/process-config-mutations-to-separate-config/package.json
+++ b/recipes/process-config-mutations-to-separate-config/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@nodejs/process-config-mutations-to-separate-config",
+  "version": "1.0.0",
+  "description": "Handle DEP0150 by migrating or commenting out mutations to process.config",
+  "type": "module",
+  "scripts": {
+    "test": "npx codemod jssg test -l typescript ./src/workflow.ts ./tests/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/userland-migrations.git",
+    "directory": "recipes/process-config-mutations-to-separate-config",
+    "bugs": "https://github.com/nodejs/userland-migrations/issues"
+  },
+  "author": "Yijun Gao",
+  "license": "MIT",
+  "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/process-config-mutations-to-separate-config/README.md",
+  "devDependencies": {
+    "@codemod.com/jssg-types": "^1.6.0"
+  }
+}

--- a/recipes/process-config-mutations-to-separate-config/src/workflow.ts
+++ b/recipes/process-config-mutations-to-separate-config/src/workflow.ts
@@ -1,0 +1,125 @@
+import type { Edit, SgNode, SgRoot } from "@codemod.com/jssg-types/main";
+import type JS from "@codemod.com/jssg-types/langs/javascript";
+
+const IMMUTABLE_COMMENT = "// process.config is now immutable and cannot be modified (DEP0150)";
+const DELETE_COMMENT =
+	"// process.config is now immutable - properties cannot be deleted (DEP0150)";
+const CONFIG_COPY_COMMENT = "// Use a separate configuration object for custom values";
+const DELETE_HINT_COMMENT =
+	"// If you need a modified copy, create a separate configuration object first";
+
+export default function transform(root: SgRoot<JS>): string | null {
+	const rootNode = root.root();
+	const sourceCode = rootNode.text();
+	const edits: Edit[] = [];
+
+	const commentedStmts = new Set<string>();
+
+	for (const { node, headerComments } of [
+		...findProcessConfigAssignments(rootNode),
+		...findProcessConfigDeletes(rootNode),
+	]) {
+		const stmt = climbToStatement(node);
+		if (!stmt) continue;
+		const key = stmtKey(stmt);
+		if (commentedStmts.has(key)) continue;
+		commentedStmts.add(key);
+		edits.push(stmt.replace(buildCommentBlock(sourceCode, stmt, headerComments)));
+	}
+
+	for (const { node } of findProcessConfigObjectAssigns(rootNode)) {
+		const parentKind = node.parent()?.kind();
+
+		if (parentKind === "variable_declarator" || parentKind === "assignment_expression") {
+			const swapped = node
+				.text()
+				.replace(/Object\.assign\(\s*process\.config\s*,/, "Object.assign({}, process.config,");
+			edits.push(node.replace(swapped));
+			continue;
+		}
+
+		if (parentKind === "expression_statement") {
+			const stmt = node.parent()!;
+			const key = stmtKey(stmt);
+			if (commentedStmts.has(key)) continue;
+			commentedStmts.add(key);
+			edits.push(
+				stmt.replace(
+					buildCommentBlock(sourceCode, stmt, [
+						IMMUTABLE_COMMENT,
+						CONFIG_COPY_COMMENT,
+					]),
+				),
+			);
+		}
+	}
+	if (!edits.length) return null;
+	return rootNode.commitEdits(edits);
+}
+
+type WriteCandidate = { node: SgNode<JS>; headerComments: string[] };
+function findProcessConfigAssignments(rootNode: SgNode<JS>): WriteCandidate[] {
+	const nodes = rootNode.findAll({
+		rule: {
+			kind: "assignment_expression",
+			has: {
+				field: "left",
+				any: [{ kind: "member_expression" }, { kind: "subscript_expression" }],
+				regex: "^process\\.config(\\.|\\[|$)",
+			},
+		},
+	});
+	return nodes.map((node) => ({
+		node,
+		headerComments: [IMMUTABLE_COMMENT, CONFIG_COPY_COMMENT],
+	}));
+}
+
+function findProcessConfigObjectAssigns(rootNode: SgNode<JS>): { node: SgNode<JS> }[] {
+	const nodes = rootNode.findAll({
+		rule: {
+			pattern: "Object.assign(process.config, $$$ARGS)",
+		},
+	});
+	return nodes.map((node) => ({ node }));
+}
+
+function findProcessConfigDeletes(rootNode: SgNode<JS>): WriteCandidate[] {
+	const nodes = rootNode.findAll({
+		rule: {
+			kind: "unary_expression",
+			regex: "^delete\\s+process\\.config(\\.|\\[|$)",
+		},
+	});
+	return nodes.map((node) => ({
+		node,
+		headerComments: [DELETE_COMMENT, DELETE_HINT_COMMENT],
+	}));
+}
+function climbToStatement(node: SgNode<JS>): SgNode<JS> | null {
+	let cur: SgNode<JS> | null = node;
+	for (let i = 0; i < 3 && cur; i++) {
+		if (cur.kind() === "expression_statement") return cur;
+		cur = cur.parent() ?? null;
+	}
+	return null;
+}
+function stmtKey(stmt: SgNode<JS>): string {
+	const r = stmt.range().start;
+	return `${r.line}:${r.column}`;
+}
+function buildCommentBlock(sourceCode: string, stmt: SgNode<JS>, header: string[]): string {
+	const indent = getLineIndent(sourceCode, stmt.range().start.index);
+	const lineEnding = sourceCode.includes("\r\n") ? "\r\n" : "\n";
+	const bodyLines = stmt
+		.text()
+		.split(/\r\n|\n|\r/)
+		.map((line) => `// ${line}`);
+	const lines = [...header, ...bodyLines];
+	return lines.map((l, i) => (i === 0 ? l : `${indent}${l}`)).join(lineEnding);
+}
+function getLineIndent(sourceCode: string, index: number): string {
+	const lineStart = sourceCode.lastIndexOf("\n", index - 1) + 1;
+	const linePrefix = sourceCode.slice(lineStart, index);
+	return linePrefix.match(/^[\t ]*/)?.[0] ?? "";
+}

--- a/recipes/process-config-mutations-to-separate-config/src/workflow.ts
+++ b/recipes/process-config-mutations-to-separate-config/src/workflow.ts
@@ -42,6 +42,7 @@ export default function transform(root: SgRoot<JS>): string | null {
 		commentedStmts.add(key);
 		edits.push(stmt.replace(buildCommentBlock(sourceCode, stmt, headerComments)));
 	}
+
 	if (objectAssign) {
 		const parent = objectAssign.parent();
 		if (parent?.is("variable_declarator") || parent?.is("assignment_expression")) {

--- a/recipes/process-config-mutations-to-separate-config/src/workflow.ts
+++ b/recipes/process-config-mutations-to-separate-config/src/workflow.ts
@@ -9,6 +9,15 @@ const CONFIG_COPY_COMMENT = "// Use a separate configuration object for custom v
 const DELETE_HINT_COMMENT =
 	"// If you need a modified copy, create a separate configuration object first";
 
+/**
+ * Applies the DEP0150 codemod for `process.config` mutations.
+ *
+ * The transform comments out unsupported direct mutations and rewrites safe
+ * `Object.assign` usages to copy from `process.config` instead of mutating it.
+ *
+ * @param root The ast-grep root node for the current source file.
+ * @returns The transformed source code, or null when no changes are needed.
+ */
 export default function transform(root: SgRoot<JS>): string | null {
 	const rootNode = root.root();
 	const sourceCode = rootNode.text();
@@ -20,26 +29,30 @@ export default function transform(root: SgRoot<JS>): string | null {
 	];
 	const objectAssign = findProcessConfigObjectAssign(rootNode);
 	if (!writeCandidates.length && !objectAssign) return null;
+
 	const commentedStmts = new Set<string>();
+
 	for (const { node, headerComments } of writeCandidates) {
 		const stmt = climbToStatement(node);
 		if (!stmt) continue;
+
 		const key = stmtKey(stmt);
 		if (commentedStmts.has(key)) continue;
+
 		commentedStmts.add(key);
 		edits.push(stmt.replace(buildCommentBlock(sourceCode, stmt, headerComments)));
 	}
 	if (objectAssign) {
-		const parentKind = objectAssign.parent()?.kind();
-		if (parentKind === "variable_declarator" || parentKind === "assignment_expression") {
+		const parent = objectAssign.parent();
+		if (parent?.is("variable_declarator") || parent?.is("assignment_expression")) {
 			const swapped = objectAssign
 				.text()
 				.replace(/Object\.assign\(\s*process\.config\s*,/, "Object.assign({}, process.config,");
 			edits.push(objectAssign.replace(swapped));
-		}
-		if (parentKind === "expression_statement") {
-			const stmt = objectAssign.parent()!;
+		} else if (parent?.is("expression_statement")) {
+			const stmt = parent;
 			const key = stmtKey(stmt);
+
 			if (!commentedStmts.has(key)) {
 				commentedStmts.add(key);
 				edits.push(
@@ -55,8 +68,16 @@ export default function transform(root: SgRoot<JS>): string | null {
 
 	return rootNode.commitEdits(edits);
 }
-
 type WriteCandidate = { node: SgNode<JS>; headerComments: string[] };
+/**
+ * Finds assignment expressions that mutate `process.config`.
+ *
+ * This covers direct property mutations such as `process.config.foo = value`
+ * and nested mutations under `process.config`.
+ *
+ * @param rootNode The ast-grep root node to search from.
+ * @returns Matching assignment nodes that mutate `process.config`.
+ */
 function findProcessConfigAssignments(rootNode: SgNode<JS>): WriteCandidate[] {
 	const nodes = rootNode.findAll({
 		rule: {
@@ -74,7 +95,15 @@ function findProcessConfigAssignments(rootNode: SgNode<JS>): WriteCandidate[] {
 		headerComments: [IMMUTABLE_COMMENT, CONFIG_COPY_COMMENT],
 	}));
 }
-
+/**
+ * Finds `Object.assign` calls that use `process.config` as the mutation target.
+ *
+ * These calls need special handling because they can either be rewritten to
+ * copy from `process.config`, or commented out when used as a standalone mutation.
+ *
+ * @param rootNode The ast-grep root node to search from.
+ * @returns Matching `Object.assign` call node.
+ */
 function findProcessConfigObjectAssign(rootNode: SgNode<JS>): SgNode<JS> {
 	const node = rootNode.find({
 		rule: {
@@ -84,7 +113,15 @@ function findProcessConfigObjectAssign(rootNode: SgNode<JS>): SgNode<JS> {
 
 	return node;
 }
-
+/**
+ * Finds delete expressions that remove properties from `process.config`.
+ *
+ * These mutations are commented out because `process.config` is immutable and
+ * deleting its properties is no longer supported.
+ *
+ * @param rootNode The ast-grep root node to search from.
+ * @returns Matching delete expression nodes that target `process.config`.
+ */
 function findProcessConfigDeletes(rootNode: SgNode<JS>): WriteCandidate[] {
 	const nodes = rootNode.findAll({
 		rule: {
@@ -98,22 +135,50 @@ function findProcessConfigDeletes(rootNode: SgNode<JS>): WriteCandidate[] {
 		headerComments: [DELETE_COMMENT, DELETE_HINT_COMMENT],
 	}));
 }
+/**
+ * Finds the nearest expression statement ancestor for a matched node.
+ *
+ * Returns null when the node is inside function arguments so nested
+ * `Object.assign(process.config, ...)` calls can be handled separately.
+ *
+ * @param node The matched ast-grep node to climb from.
+ * @returns The nearest expression statement ancestor, or null when none exists.
+ */
 function climbToStatement(node: SgNode<JS>): SgNode<JS> | null {
 	let cur: SgNode<JS> | null = node.parent();
 	while (cur) {
-		const kind = cur.kind();
-		if (kind === "arguments") return null;
-		if (kind === "expression_statement") return cur;
+		if (cur.is("arguments")) return null;
+		if (cur.is("expression_statement")) return cur;
 		cur = cur.parent() ?? null;
 	}
 
 	return null;
 }
+/**
+ * Builds a stable key for a statement based on its source position.
+ *
+ * This prevents applying duplicate comment edits when multiple matches are
+ * found in the same statement.
+ *
+ * @param stmt The statement node to create a key for.
+ * @returns A stable key representing the statement position.
+ */
 function stmtKey(stmt: SgNode<JS>): string {
 	const r = stmt.range().start;
 
 	return `${r.line}:${r.column}`;
 }
+/**
+ * Builds the replacement text for commenting out a statement.
+ *
+ * The generated block preserves the original indentation and line ending, then
+ * prepends explanatory comments before the commented statement body.
+ *
+ * @param sourceCode The full original source code.
+ * @param stmt The statement node being commented out.
+ * @param header The explanatory comment lines to place before the statement.
+ * @returns The replacement text for the commented-out statement block.
+ */
 function buildCommentBlock(sourceCode: string, stmt: SgNode<JS>, header: string[]): string {
 	const indent = getLineIndent(sourceCode, stmt.range().start.index);
 	const lineEnding = sourceCode.includes("\r\n") ? "\r\n" : "\n";

--- a/recipes/process-config-mutations-to-separate-config/src/workflow.ts
+++ b/recipes/process-config-mutations-to-separate-config/src/workflow.ts
@@ -1,5 +1,6 @@
 import type { Edit, SgNode, SgRoot } from "@codemod.com/jssg-types/main";
 import type JS from "@codemod.com/jssg-types/langs/javascript";
+import { getLineIndent } from "@nodejs/codemod-utils/ast-grep/indent";
 
 const IMMUTABLE_COMMENT = "// process.config is now immutable and cannot be modified (DEP0150)";
 const DELETE_COMMENT =
@@ -13,12 +14,14 @@ export default function transform(root: SgRoot<JS>): string | null {
 	const sourceCode = rootNode.text();
 	const edits: Edit[] = [];
 
-	const commentedStmts = new Set<string>();
-
-	for (const { node, headerComments } of [
+	const writeCandidates = [
 		...findProcessConfigAssignments(rootNode),
 		...findProcessConfigDeletes(rootNode),
-	]) {
+	];
+	const objectAssign = findProcessConfigObjectAssign(rootNode);
+	if (!writeCandidates.length && !objectAssign) return null;
+	const commentedStmts = new Set<string>();
+	for (const { node, headerComments } of writeCandidates) {
 		const stmt = climbToStatement(node);
 		if (!stmt) continue;
 		const key = stmtKey(stmt);
@@ -26,34 +29,30 @@ export default function transform(root: SgRoot<JS>): string | null {
 		commentedStmts.add(key);
 		edits.push(stmt.replace(buildCommentBlock(sourceCode, stmt, headerComments)));
 	}
-
-	for (const { node } of findProcessConfigObjectAssigns(rootNode)) {
-		const parentKind = node.parent()?.kind();
-
+	if (objectAssign) {
+		const parentKind = objectAssign.parent()?.kind();
 		if (parentKind === "variable_declarator" || parentKind === "assignment_expression") {
-			const swapped = node
+			const swapped = objectAssign
 				.text()
 				.replace(/Object\.assign\(\s*process\.config\s*,/, "Object.assign({}, process.config,");
-			edits.push(node.replace(swapped));
-			continue;
+			edits.push(objectAssign.replace(swapped));
 		}
-
 		if (parentKind === "expression_statement") {
-			const stmt = node.parent()!;
+			const stmt = objectAssign.parent()!;
 			const key = stmtKey(stmt);
-			if (commentedStmts.has(key)) continue;
-			commentedStmts.add(key);
-			edits.push(
-				stmt.replace(
-					buildCommentBlock(sourceCode, stmt, [
-						IMMUTABLE_COMMENT,
-						CONFIG_COPY_COMMENT,
-					]),
-				),
-			);
+			if (!commentedStmts.has(key)) {
+				commentedStmts.add(key);
+				edits.push(
+					stmt.replace(
+						buildCommentBlock(sourceCode, stmt, [IMMUTABLE_COMMENT, CONFIG_COPY_COMMENT]),
+					),
+				);
+			}
 		}
 	}
+
 	if (!edits.length) return null;
+
 	return rootNode.commitEdits(edits);
 }
 
@@ -69,19 +68,21 @@ function findProcessConfigAssignments(rootNode: SgNode<JS>): WriteCandidate[] {
 			},
 		},
 	});
+
 	return nodes.map((node) => ({
 		node,
 		headerComments: [IMMUTABLE_COMMENT, CONFIG_COPY_COMMENT],
 	}));
 }
 
-function findProcessConfigObjectAssigns(rootNode: SgNode<JS>): { node: SgNode<JS> }[] {
-	const nodes = rootNode.findAll({
+function findProcessConfigObjectAssign(rootNode: SgNode<JS>): SgNode<JS> {
+	const node = rootNode.find({
 		rule: {
 			pattern: "Object.assign(process.config, $$$ARGS)",
 		},
 	});
-	return nodes.map((node) => ({ node }));
+
+	return node;
 }
 
 function findProcessConfigDeletes(rootNode: SgNode<JS>): WriteCandidate[] {
@@ -91,21 +92,26 @@ function findProcessConfigDeletes(rootNode: SgNode<JS>): WriteCandidate[] {
 			regex: "^delete\\s+process\\.config(\\.|\\[|$)",
 		},
 	});
+
 	return nodes.map((node) => ({
 		node,
 		headerComments: [DELETE_COMMENT, DELETE_HINT_COMMENT],
 	}));
 }
 function climbToStatement(node: SgNode<JS>): SgNode<JS> | null {
-	let cur: SgNode<JS> | null = node;
-	for (let i = 0; i < 3 && cur; i++) {
-		if (cur.kind() === "expression_statement") return cur;
+	let cur: SgNode<JS> | null = node.parent();
+	while (cur) {
+		const kind = cur.kind();
+		if (kind === "arguments") return null;
+		if (kind === "expression_statement") return cur;
 		cur = cur.parent() ?? null;
 	}
+
 	return null;
 }
 function stmtKey(stmt: SgNode<JS>): string {
 	const r = stmt.range().start;
+
 	return `${r.line}:${r.column}`;
 }
 function buildCommentBlock(sourceCode: string, stmt: SgNode<JS>, header: string[]): string {
@@ -116,10 +122,6 @@ function buildCommentBlock(sourceCode: string, stmt: SgNode<JS>, header: string[
 		.split(/\r\n|\n|\r/)
 		.map((line) => `// ${line}`);
 	const lines = [...header, ...bodyLines];
+
 	return lines.map((l, i) => (i === 0 ? l : `${indent}${l}`)).join(lineEnding);
-}
-function getLineIndent(sourceCode: string, index: number): string {
-	const lineStart = sourceCode.lastIndexOf("\n", index - 1) + 1;
-	const linePrefix = sourceCode.slice(lineStart, index);
-	return linePrefix.match(/^[\t ]*/)?.[0] ?? "";
 }

--- a/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-assignment/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-assignment/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable and cannot be modified (DEP0150)
+// Use a separate configuration object for custom values
+// process.config["custom"] = "value";

--- a/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-assignment/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-assignment/input.js
@@ -1,0 +1,1 @@
+process.config["custom"] = "value";

--- a/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-delete/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-delete/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable - properties cannot be deleted (DEP0150)
+// If you need a modified copy, create a separate configuration object first
+// delete process.config["custom"];

--- a/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-delete/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/bracket-notation-delete/input.js
@@ -1,0 +1,1 @@
+delete process.config["custom"];

--- a/recipes/process-config-mutations-to-separate-config/tests/conditional-modification/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/conditional-modification/expected.js
@@ -1,0 +1,5 @@
+if (someCondition) {
+	// process.config is now immutable and cannot be modified (DEP0150)
+	// Use a separate configuration object for custom values
+	// process.config.variables.debug = true;
+}

--- a/recipes/process-config-mutations-to-separate-config/tests/conditional-modification/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/conditional-modification/input.js
@@ -1,0 +1,3 @@
+if (someCondition) {
+	process.config.variables.debug = true;
+}

--- a/recipes/process-config-mutations-to-separate-config/tests/direct-assignment/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/direct-assignment/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable and cannot be modified (DEP0150)
+// Use a separate configuration object for custom values
+// process.config.target_defaults = { cflags: [] };

--- a/recipes/process-config-mutations-to-separate-config/tests/direct-assignment/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/direct-assignment/input.js
@@ -1,0 +1,1 @@
+process.config.target_defaults = { cflags: [] };

--- a/recipes/process-config-mutations-to-separate-config/tests/nested-property/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/nested-property/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable and cannot be modified (DEP0150)
+// Use a separate configuration object for custom values
+// process.config.variables.node_prefix = "/custom/path";

--- a/recipes/process-config-mutations-to-separate-config/tests/nested-property/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/nested-property/input.js
@@ -1,0 +1,1 @@
+process.config.variables.node_prefix = "/custom/path";

--- a/recipes/process-config-mutations-to-separate-config/tests/nested-write-unchanged/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/nested-write-unchanged/expected.js
@@ -1,0 +1,1 @@
+console.log((process.config.foo = "bar"));

--- a/recipes/process-config-mutations-to-separate-config/tests/nested-write-unchanged/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/nested-write-unchanged/input.js
@@ -1,0 +1,1 @@
+console.log((process.config.foo = "bar"));

--- a/recipes/process-config-mutations-to-separate-config/tests/new-property/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/new-property/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable and cannot be modified (DEP0150)
+// Use a separate configuration object for custom values
+// process.config.custom = "value";

--- a/recipes/process-config-mutations-to-separate-config/tests/new-property/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/new-property/input.js
@@ -1,0 +1,1 @@
+process.config.custom = "value";

--- a/recipes/process-config-mutations-to-separate-config/tests/object-assign-bare/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/object-assign-bare/expected.js
@@ -1,0 +1,3 @@
+// process.config is now immutable and cannot be modified (DEP0150)
+// Use a separate configuration object for custom values
+// Object.assign(process.config, { custom: "settings" });

--- a/recipes/process-config-mutations-to-separate-config/tests/object-assign-bare/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/object-assign-bare/input.js
@@ -1,0 +1,1 @@
+Object.assign(process.config, { custom: "settings" });

--- a/recipes/process-config-mutations-to-separate-config/tests/object-assign-captured/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/object-assign-captured/expected.js
@@ -1,0 +1,1 @@
+const config = Object.assign({}, process.config, { custom: "settings" });

--- a/recipes/process-config-mutations-to-separate-config/tests/object-assign-captured/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/object-assign-captured/input.js
@@ -1,0 +1,1 @@
+const config = Object.assign(process.config, { custom: "settings" });

--- a/recipes/process-config-mutations-to-separate-config/tests/read-only/expected.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/read-only/expected.js
@@ -1,0 +1,2 @@
+const nodeVersion = process.config.variables.node_version;
+console.log("Node version:", nodeVersion);

--- a/recipes/process-config-mutations-to-separate-config/tests/read-only/input.js
+++ b/recipes/process-config-mutations-to-separate-config/tests/read-only/input.js
@@ -1,0 +1,2 @@
+const nodeVersion = process.config.variables.node_version;
+console.log("Node version:", nodeVersion);

--- a/recipes/process-config-mutations-to-separate-config/workflow.yaml
+++ b/recipes/process-config-mutations-to-separate-config/workflow.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
+version: "1"
+
+nodes:
+  - id: apply-transforms
+    name: Apply AST Transformations
+    type: automatic
+    runtime:
+      type: direct
+    steps:
+      - name: Handle DEP0150 - process.config is now immutable
+        js-ast-grep:
+          js_file: src/workflow.ts
+          base_path: .
+          include:
+            - "**/*.cjs"
+            - "**/*.cts"
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.mjs"
+            - "**/*.mts"
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript


### PR DESCRIPTION
## Summary

Adds a DEP0150 migration recipe to handle `process.config` mutations after it became immutable in Node.js v19.
The recipe handles:

- Direct assignments to `process.config` properties
- Nested property assignments
- Bracket notation assignments
- `delete process.config...` expressions
- Bare `Object.assign(process.config, ...)` calls
- Captured `Object.assign(process.config, ...)` calls by rewriting them to copy into a new object
- Read-only `process.config` usage, which is preserved unchanged

Closes #408.

## Tests

- Ran `npm test` in `recipes/process-config-mutations-to-separate-config`
- Added tests:
  - `bracket-notation-assignment`
  - `bracket-notation-delete`
  - `conditional-modification`
  - `direct-assignment`
  - `nested-property`
  - `nested-write-unchanged`
  - `new-property`
  - `object-assign-bare`
  - `object-assign-captured`
  - `read-only`
  
This is my first contribution to this project, so feedback is very welcome. I’m happy to make any changes if needed.