### PR TITLE
feat(colors-to-util-styletext): add migration recipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,6 +424,10 @@
       "resolved": "utils",
       "link": true
     },
+    "node_modules/@nodejs/colors-to-util-styletext": {
+      "resolved": "recipes/colors-to-util-styletext",
+      "link": true
+    },
     "node_modules/@nodejs/create-require-from-path": {
       "resolved": "recipes/create-require-from-path",
       "link": true
@@ -748,6 +752,17 @@
       },
       "devDependencies": {
         "@codemod.com/jssg-types": "^1.6.1"
+      }
+    },
+    "recipes/colors-to-util-styletext": {
+      "name": "@nodejs/colors-to-util-styletext",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nodejs/codemod-utils": "*"
+      },
+      "devDependencies": {
+        "@codemod.com/jssg-types": "^1.6.0"
       }
     },
     "recipes/create-require-from-path": {

--- a/recipes/colors-to-util-styletext/README.md
+++ b/recipes/colors-to-util-styletext/README.md
@@ -1,0 +1,41 @@
+# Colors to util.styleText
+
+This recipe migrates compatible `colors` package usage to Node.js built-in `util.styleText`.
+
+## Examples
+
+```diff
+- const colors = require('colors');
++ const { styleText } = require('node:util');
+- console.log('Error message'.red);
++ console.log(styleText('red', 'Error message'));
+```
+
+```diff
+- import colors from 'colors';
++ import { styleText } from 'node:util';
+- console.log('Success'.green.bold);
++ console.log(styleText(['green', 'bold'], 'Success'));
+```
+
+```diff
+- const colors = require('colors/safe');
++ const { styleText } = require('node:util');
+- console.log(colors.green('Success message'));
++ console.log(styleText('green', 'Success message'));
+```
+
+## Usage
+
+Run this codemod with:
+
+```sh
+npx codemod nodejs/colors-to-util-styletext
+```
+
+## Compatibility
+
+- Removes the `colors` dependency from package.json automatically.
+- Supports string prototype colors and modifiers, including chained styles.
+- Supports `colors/safe` namespace calls.
+- Unsupported extras such as `rainbow`, `zebra`, `america`, `trap`, and `random` are left unchanged and reported for manual review.

--- a/recipes/colors-to-util-styletext/README.md
+++ b/recipes/colors-to-util-styletext/README.md
@@ -25,14 +25,6 @@ This recipe migrates compatible `colors` package usage to Node.js built-in `util
 + console.log(styleText('green', 'Success message'));
 ```
 
-## Usage
-
-Run this codemod with:
-
-```sh
-npx codemod nodejs/colors-to-util-styletext
-```
-
 ## Compatibility
 
 - Removes the `colors` dependency from package.json automatically.

--- a/recipes/colors-to-util-styletext/codemod.yaml
+++ b/recipes/colors-to-util-styletext/codemod.yaml
@@ -1,0 +1,26 @@
+schema_version: "1.0"
+name: "@nodejs/colors-to-util-styletext"
+version: 1.0.0
+capabilities:
+  - fs
+  - child_process
+description: Migrate from the colors package to Node.js's built-in util.styleText API
+author: Herrtian
+license: MIT
+workflow: workflow.yaml
+category: migration
+repository: https://github.com/nodejs/userland-migrations
+
+targets:
+  languages:
+    - javascript
+    - typescript
+
+keywords:
+  - transformation
+  - migration
+  - nodejs
+
+registry:
+  access: public
+  visibility: public

--- a/recipes/colors-to-util-styletext/codemod.yaml
+++ b/recipes/colors-to-util-styletext/codemod.yaml
@@ -17,9 +17,9 @@ targets:
     - typescript
 
 keywords:
-  - transformation
-  - migration
   - nodejs
+  - colors
+  - styleText
 
 registry:
   access: public

--- a/recipes/colors-to-util-styletext/package.json
+++ b/recipes/colors-to-util-styletext/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@nodejs/colors-to-util-styletext",
+    "version": "1.0.0",
+    "description": "Migrate from the colors package to Node.js's built-in util.styleText API",
+    "type": "module",
+    "scripts": {
+        "test": "node --run test:workflow && node --run test:remove-dependencies",
+        "test:workflow": "npx codemod jssg test -l typescript ./src/workflow.ts ./tests",
+        "test:remove-dependencies": "npx codemod jssg test -l json ./src/remove-dependencies.ts ./tests/remove-dependencies --allow-child-process --allow-fs --strictness cst"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejs/userland-migrations.git",
+        "directory": "recipes/colors-to-util-styletext",
+        "bugs": "https://github.com/nodejs/userland-migrations/issues"
+    },
+    "author": "Herrtian",
+    "license": "MIT",
+    "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/colors-to-util-styletext/README.md",
+    "devDependencies": {
+        "@codemod.com/jssg-types": "^1.6.0"
+    },
+    "dependencies": {
+        "@nodejs/codemod-utils": "*"
+    }
+}

--- a/recipes/colors-to-util-styletext/src/remove-dependencies.ts
+++ b/recipes/colors-to-util-styletext/src/remove-dependencies.ts
@@ -1,0 +1,13 @@
+import type { Transform } from '@codemod.com/jssg-types/main';
+import type Json from '@codemod.com/jssg-types/langs/json';
+import removeDependencies from '@nodejs/codemod-utils/remove-dependencies';
+
+const transform: Transform<Json> = async (root) => {
+	return removeDependencies(['colors', '@types/colors'], {
+		packageJsonPath: root.filename(),
+		runInstall: false,
+		persistFileWrite: false,
+	});
+};
+
+export default transform;

--- a/recipes/colors-to-util-styletext/src/workflow.ts
+++ b/recipes/colors-to-util-styletext/src/workflow.ts
@@ -73,11 +73,22 @@ export default function transform(root: SgRoot<Js>): string | null {
 
 	const colorsStatements = getModuleDependencies(root, colorsModule);
 	const safeColorsStatements = getModuleDependencies(root, safeColorsModule);
+	const safeThenCalls = getSafeDynamicImportThenCalls(rootNode);
 
-	if (!colorsStatements.length && !safeColorsStatements.length) return null;
+	if (
+		!colorsStatements.length &&
+		!safeColorsStatements.length &&
+		!safeThenCalls.length
+	) {
+		return null;
+	}
 
 	for (const statement of safeColorsStatements) {
 		processStatement(rootNode, statement, edits, true);
+	}
+
+	for (const thenCall of safeThenCalls) {
+		processDynamicImportThenCall(thenCall, edits);
 	}
 
 	for (const statement of colorsStatements) {
@@ -121,6 +132,11 @@ function processStatement(
 		if (importReplacement) {
 			edits.push(statement.replace(importReplacement));
 		}
+	} else if (
+		isSafeImport &&
+		['import_statement', 'variable_declarator'].includes(statement.kind())
+	) {
+		edits.push(removeUnusedSafeImport(statement));
 	}
 }
 
@@ -259,6 +275,36 @@ function processDestructuredSafeCalls(
 
 			replaceSafeCall(rootNode, call, styles, edits);
 		}
+	}
+}
+
+/** Rewrites colors/safe usages inside dynamic import .then callbacks. */
+function processDynamicImportThenCall(
+	thenCall: SgNode<Js>,
+	edits: Edit[],
+): void {
+	const callback = getCallArguments(thenCall)[0];
+
+	if (!callback) return;
+
+	const destructuredParam = callback.find({
+		rule: { kind: 'object_pattern' },
+	});
+
+	if (!destructuredParam) return;
+
+	const destructuredNames = getNamesFromObjectPattern(destructuredParam);
+	const editCountBeforeCall = edits.length;
+
+	processDestructuredSafeCalls(callback, destructuredNames, edits);
+
+	if (edits.length > editCountBeforeCall) {
+		const dynamicImport = thenCall.field('function')?.field('object');
+
+		if (dynamicImport) {
+			edits.push(dynamicImport.replace('import("node:util")'));
+		}
+		edits.push(destructuredParam.replace('{ styleText }'));
 	}
 }
 
@@ -429,15 +475,16 @@ function hasUnsupportedStyles(styles: string[]): boolean {
 
 /** Returns the first real argument for a colors/safe call. */
 function getFirstCallArgument(call: SgNode<Js>): string | null {
+	return getCallArguments(call)[0]?.text() ?? null;
+}
+
+/** Returns named call arguments. */
+function getCallArguments(call: SgNode<Js>): Array<SgNode<Js>> {
 	const args = call.field('arguments');
 
-	if (!args) return null;
+	if (!args) return [];
 
-	const argsList = args.children().filter((child) => child.isNamed());
-
-	if (argsList.length === 0) return null;
-
-	return argsList[0].text();
+	return args.children().filter((child) => child.isNamed());
 }
 
 /** Builds a util.styleText call for one or more styles. */
@@ -466,6 +513,90 @@ function createImportReplacement(statement: SgNode<Js>): string {
 	}
 
 	return '';
+}
+
+/** Finds `import("colors/safe").then(...)` calls. */
+function getSafeDynamicImportThenCalls(rootNode: SgNode<Js>): Array<SgNode<Js>> {
+	return rootNode
+		.findAll({
+			rule: { kind: 'call_expression' },
+		})
+		.filter((call) => {
+			const functionExpr = call.field('function');
+
+			if (functionExpr?.kind() !== 'member_expression') return false;
+
+			const object = functionExpr.field('object');
+			const property = functionExpr.field('property');
+
+			return property?.text() === 'then' && isSafeDynamicImport(object);
+		});
+}
+
+/** Checks for `import("colors/safe")`. */
+function isSafeDynamicImport(node: SgNode<Js> | null): boolean {
+	if (node?.kind() !== 'call_expression') return false;
+
+	const functionExpr = node.field('function');
+	const moduleName = getFirstCallArgument(node);
+
+	return (
+		functionExpr?.text() === 'import' &&
+		(moduleName === '"colors/safe"' || moduleName === "'colors/safe'")
+	);
+}
+
+/** Removes an unused colors/safe dependency statement. */
+function removeUnusedSafeImport(statement: SgNode<Js>): Edit {
+	const parent = statement.parent();
+
+	if (
+		parent &&
+		['lexical_declaration', 'variable_declaration'].includes(parent.kind())
+	) {
+		return parent.replace('');
+	}
+
+	return statement.replace('');
+}
+
+/** Returns destructured names from an object pattern node. */
+function getNamesFromObjectPattern(
+	objectPattern: SgNode<Js>,
+): Array<{ imported: string; local: string }> {
+	const names: Array<{ imported: string; local: string }> = [];
+	const properties = objectPattern.findAll({
+		rule: {
+			any: [
+				{ kind: 'shorthand_property_identifier_pattern' },
+				{ kind: 'pair_pattern' },
+			],
+		},
+	});
+
+	for (const prop of properties) {
+		const propKind = prop.kind();
+
+		switch (propKind) {
+			case 'shorthand_property_identifier_pattern': {
+				const name = prop.text();
+
+				names.push({ imported: name, local: name });
+				break;
+			}
+			case 'pair_pattern': {
+				const key = prop.field('key');
+				const value = prop.field('value');
+
+				if (key && value) {
+					names.push({ imported: key.text(), local: value.text() });
+				}
+				break;
+			}
+		}
+	}
+
+	return names;
 }
 
 /** Skips intermediate members so only the full style chain is replaced. */

--- a/recipes/colors-to-util-styletext/src/workflow.ts
+++ b/recipes/colors-to-util-styletext/src/workflow.ts
@@ -178,16 +178,23 @@ function getDestructuredNames(
 		});
 
 		for (const prop of properties) {
-			if (prop.kind() === 'shorthand_property_identifier_pattern') {
-				const name = prop.text();
+			const propKind = prop.kind();
 
-				names.push({ imported: name, local: name });
-			} else if (prop.kind() === 'pair_pattern') {
-				const key = prop.field('key');
-				const value = prop.field('value');
+			switch (propKind) {
+				case 'shorthand_property_identifier_pattern': {
+					const name = prop.text();
 
-				if (key && value) {
-					names.push({ imported: key.text(), local: value.text() });
+					names.push({ imported: name, local: name });
+					break;
+				}
+				case 'pair_pattern': {
+					const key = prop.field('key');
+					const value = prop.field('value');
+
+					if (key && value) {
+						names.push({ imported: key.text(), local: value.text() });
+					}
+					break;
 				}
 			}
 		}
@@ -344,13 +351,14 @@ function extractNamespaceStyles(
 		if (!object || property?.kind() !== 'property_identifier') return false;
 
 		const propertyName = normalizeStyle(property.text());
+		const objectKind = object.kind();
 
-		if (object.kind() === 'identifier' && object.text() === binding) {
+		if (objectKind === 'identifier' && object.text() === binding) {
 			styles.push(propertyName);
 			return true;
 		}
 
-		if (object.kind() === 'member_expression' && traverse(object)) {
+		if (objectKind === 'member_expression' && traverse(object)) {
 			styles.push(propertyName);
 			return true;
 		}
@@ -376,7 +384,7 @@ function extractPrototypeStyles(
 
 	if (!isSupportedOrKnownUnsupported(style)) return null;
 
-	if (object.kind() === 'member_expression') {
+	if (object.is('member_expression')) {
 		const nested = extractPrototypeStyles(object);
 
 		if (!nested) return null;
@@ -420,10 +428,7 @@ function getFirstCallArgument(call: SgNode<Js>): string | null {
 
 	if (!args) return null;
 
-	const argsList = args.children().filter((child) => {
-		const excluded = [',', '(', ')'];
-		return !excluded.includes(child.kind());
-	});
+	const argsList = args.children().filter((child) => child.isNamed());
 
 	if (argsList.length === 0) return null;
 
@@ -441,16 +446,18 @@ function createStyleTextReplacement(styles: string[], textArg: string): string {
 
 /** Builds the matching util.styleText import or require replacement. */
 function createImportReplacement(statement: SgNode<Js>): string {
-	if (statement.kind() === 'import_statement') {
-		return 'import { styleText } from "node:util";';
-	}
+	const statementKind = statement.kind();
 
-	if (statement.kind() === 'variable_declarator') {
-		if (statement.field('value')?.kind() === 'await_expression') {
-			return '{ styleText } = await import("node:util")';
+	switch (statementKind) {
+		case 'import_statement':
+			return 'import { styleText } from "node:util";';
+		case 'variable_declarator': {
+			if (statement.field('value')?.kind() === 'await_expression') {
+				return '{ styleText } = await import("node:util")';
+			}
+
+			return '{ styleText } = require("node:util")';
 		}
-
-		return '{ styleText } = require("node:util")';
 	}
 
 	return '';

--- a/recipes/colors-to-util-styletext/src/workflow.ts
+++ b/recipes/colors-to-util-styletext/src/workflow.ts
@@ -66,6 +66,7 @@ const UNSUPPORTED_EXTRAS = new Set([
 	'zebra',
 ]);
 
+/** Converts supported colors imports and usages to util.styleText. */
 export default function transform(root: SgRoot<Js>): string | null {
 	const rootNode = root.root();
 	const edits: Edit[] = [];
@@ -88,6 +89,7 @@ export default function transform(root: SgRoot<Js>): string | null {
 	return rootNode.commitEdits(edits);
 }
 
+/** Rewrites one colors dependency statement and its related usages. */
 function processStatement(
 	rootNode: SgNode<Js>,
 	statement: SgNode<Js>,
@@ -122,9 +124,10 @@ function processStatement(
 	}
 }
 
+/** Returns the local binding for namespace imports/requires when one exists. */
 function resolveOptionalBinding(statement: SgNode<Js>): string | undefined {
 	if (
-		statement.kind() === 'import_statement' &&
+		statement.is('import_statement') &&
 		!statement.find({ rule: { kind: 'import_clause' } })
 	) {
 		return undefined;
@@ -133,12 +136,14 @@ function resolveOptionalBinding(statement: SgNode<Js>): string | undefined {
 	return resolveBindingPath(statement, '$');
 }
 
+/** Collects imported colors names from destructured imports and requires. */
 function getDestructuredNames(
 	statement: SgNode<Js>,
 ): Array<{ imported: string; local: string }> {
 	const names: Array<{ imported: string; local: string }> = [];
+	const statementKind = statement.kind();
 
-	if (statement.kind() === 'import_statement') {
+	if (statementKind === 'import_statement') {
 		const namedImports = statement.find({
 			rule: { kind: 'named_imports' },
 		});
@@ -158,7 +163,7 @@ function getDestructuredNames(
 				names.push({ imported, local: alias ? alias.text() : imported });
 			}
 		}
-	} else if (statement.kind() === 'variable_declarator') {
+	} else if (statementKind === 'variable_declarator') {
 		const nameField = statement.field('name');
 
 		if (nameField?.kind() !== 'object_pattern') return names;
@@ -191,6 +196,7 @@ function getDestructuredNames(
 	return names;
 }
 
+/** Rewrites calls that use destructured colors/safe helpers. */
 function processDestructuredSafeCalls(
 	rootNode: SgNode<Js>,
 	destructuredNames: Array<{ imported: string; local: string }>,
@@ -233,13 +239,18 @@ function processDestructuredSafeCalls(
 			const styles =
 				functionExpr.kind() === 'identifier'
 					? [normalizeStyle(imported)]
-					: extractNamespaceStyles(functionExpr, local, normalizeStyle(imported));
+					: extractNamespaceStyles(
+							functionExpr,
+							local,
+							normalizeStyle(imported),
+						);
 
 			replaceSafeCall(rootNode, call, styles, edits);
 		}
 	}
 }
 
+/** Rewrites calls accessed through a colors/safe namespace binding. */
 function processSafeNamespaceCalls(
 	rootNode: SgNode<Js>,
 	binding: string,
@@ -259,13 +270,14 @@ function processSafeNamespaceCalls(
 	}
 }
 
+/** Replaces a safe colors call with util.styleText when it can be mapped. */
 function replaceSafeCall(
 	rootNode: SgNode<Js>,
 	call: SgNode<Js>,
 	styles: string[],
 	edits: Edit[],
 ): void {
-	if (styles.length === 0) return;
+	if (!styles.length) return;
 
 	if (hasUnsupportedStyles(styles)) {
 		warnOnUnsupportedStyle(styles, rootNode, call);
@@ -279,6 +291,7 @@ function replaceSafeCall(
 	edits.push(call.replace(createStyleTextReplacement(styles, textArg)));
 }
 
+/** Rewrites colors prototype style chains such as "text".green. */
 function processPrototypeStyles(
 	rootNode: SgNode<Js>,
 	edits: Edit[],
@@ -289,13 +302,18 @@ function processPrototypeStyles(
 	});
 
 	for (const memberExpression of memberExpressions) {
-		if (isNestedStyleChain(memberExpression)) continue;
-		if (isCallFunction(memberExpression)) continue;
+		if (
+			isNestedStyleChain(memberExpression) ||
+			isCallFunction(memberExpression)
+		) {
+			continue;
+		}
 
 		const prototypeStyle = extractPrototypeStyles(memberExpression);
 
-		if (!prototypeStyle) continue;
-		if (blockedPrototypeBases.has(prototypeStyle.text)) continue;
+		if (!prototypeStyle || blockedPrototypeBases.has(prototypeStyle.text)) {
+			continue;
+		}
 
 		if (hasUnsupportedStyles(prototypeStyle.styles)) {
 			warnOnUnsupportedStyle(prototypeStyle.styles, rootNode, memberExpression);
@@ -310,6 +328,7 @@ function processPrototypeStyles(
 	}
 }
 
+/** Reads the style chain from a safe namespace call. */
 function extractNamespaceStyles(
 	node: SgNode<Js>,
 	binding: string,
@@ -317,6 +336,7 @@ function extractNamespaceStyles(
 ): string[] {
 	const styles = initialStyle ? [initialStyle] : [];
 
+	/** Walks a member chain until it reaches the expected namespace binding. */
 	function traverse(current: SgNode<Js>): boolean {
 		const object = current.field('object');
 		const property = current.field('property');
@@ -343,6 +363,7 @@ function extractNamespaceStyles(
 	return styles;
 }
 
+/** Reads the style chain from a prototype access expression. */
 function extractPrototypeStyles(
 	node: SgNode<Js>,
 ): { text: string; styles: string[] } | null {
@@ -368,6 +389,7 @@ function extractPrototypeStyles(
 	return { text: object.text(), styles: [style] };
 }
 
+/** Checks whether a node can safely be used as the text argument. */
 function isSupportedPrototypeBase(node: SgNode<Js>): boolean {
 	return [
 		'identifier',
@@ -377,18 +399,22 @@ function isSupportedPrototypeBase(node: SgNode<Js>): boolean {
 	].includes(node.kind());
 }
 
+/** Normalizes colors aliases to util.styleText names. */
 function normalizeStyle(style: string): string {
 	return COMPAT_MAP[style] || style;
 }
 
+/** Keeps traversal limited to colors styles that are known to the recipe. */
 function isSupportedOrKnownUnsupported(style: string): boolean {
 	return SUPPORTED_STYLES.has(style) || UNSUPPORTED_EXTRAS.has(style);
 }
 
+/** Detects styles that colors supports but util.styleText does not. */
 function hasUnsupportedStyles(styles: string[]): boolean {
 	return styles.some((style) => !SUPPORTED_STYLES.has(style));
 }
 
+/** Returns the first real argument for a colors/safe call. */
 function getFirstCallArgument(call: SgNode<Js>): string | null {
 	const args = call.field('arguments');
 
@@ -404,6 +430,7 @@ function getFirstCallArgument(call: SgNode<Js>): string | null {
 	return argsList[0].text();
 }
 
+/** Builds a util.styleText call for one or more styles. */
 function createStyleTextReplacement(styles: string[], textArg: string): string {
 	if (styles.length === 1) {
 		return `styleText("${styles[0]}", ${textArg})`;
@@ -412,6 +439,7 @@ function createStyleTextReplacement(styles: string[], textArg: string): string {
 	return `styleText([${styles.map((style) => `"${style}"`).join(', ')}], ${textArg})`;
 }
 
+/** Builds the matching util.styleText import or require replacement. */
 function createImportReplacement(statement: SgNode<Js>): string {
 	if (statement.kind() === 'import_statement') {
 		return 'import { styleText } from "node:util";';
@@ -428,6 +456,7 @@ function createImportReplacement(statement: SgNode<Js>): string {
 	return '';
 }
 
+/** Skips intermediate members so only the full style chain is replaced. */
 function isNestedStyleChain(node: SgNode<Js>): boolean {
 	const parent = node.parent();
 
@@ -443,6 +472,7 @@ function isNestedStyleChain(node: SgNode<Js>): boolean {
 	);
 }
 
+/** Skips member expressions that are already part of a call expression. */
 function isCallFunction(node: SgNode<Js>): boolean {
 	const parent = node.parent();
 
@@ -451,6 +481,7 @@ function isCallFunction(node: SgNode<Js>): boolean {
 	return parent.field('function')?.text() === node.text();
 }
 
+/** Emits a review warning for colors styles that cannot be mapped. */
 function warnOnUnsupportedStyle(
 	styles: string[],
 	rootNode: SgNode<Js>,

--- a/recipes/colors-to-util-styletext/src/workflow.ts
+++ b/recipes/colors-to-util-styletext/src/workflow.ts
@@ -1,0 +1,468 @@
+import type { Edit, SgNode, SgRoot } from '@codemod.com/jssg-types/main';
+import type Js from '@codemod.com/jssg-types/langs/javascript';
+import { getModuleDependencies } from '@nodejs/codemod-utils/ast-grep/module-dependencies';
+import { resolveBindingPath } from '@nodejs/codemod-utils/ast-grep/resolve-binding-path';
+
+const colorsModule = 'colors';
+const safeColorsModule = 'colors/safe';
+
+const COMPAT_MAP: Record<string, string> = {
+	bgGrey: 'bgGray',
+	grey: 'gray',
+};
+
+const SUPPORTED_STYLES = new Set([
+	'black',
+	'red',
+	'green',
+	'yellow',
+	'blue',
+	'magenta',
+	'cyan',
+	'white',
+	'gray',
+	'grey',
+	'blackBright',
+	'redBright',
+	'greenBright',
+	'yellowBright',
+	'blueBright',
+	'magentaBright',
+	'cyanBright',
+	'whiteBright',
+	'bgBlack',
+	'bgRed',
+	'bgGreen',
+	'bgYellow',
+	'bgBlue',
+	'bgMagenta',
+	'bgCyan',
+	'bgWhite',
+	'bgGray',
+	'bgGrey',
+	'bgBlackBright',
+	'bgRedBright',
+	'bgGreenBright',
+	'bgYellowBright',
+	'bgBlueBright',
+	'bgMagentaBright',
+	'bgCyanBright',
+	'bgWhiteBright',
+	'reset',
+	'bold',
+	'dim',
+	'italic',
+	'underline',
+	'inverse',
+	'hidden',
+	'strikethrough',
+]);
+
+const UNSUPPORTED_EXTRAS = new Set([
+	'america',
+	'rainbow',
+	'random',
+	'trap',
+	'zebra',
+]);
+
+export default function transform(root: SgRoot<Js>): string | null {
+	const rootNode = root.root();
+	const edits: Edit[] = [];
+
+	const colorsStatements = getModuleDependencies(root, colorsModule);
+	const safeColorsStatements = getModuleDependencies(root, safeColorsModule);
+
+	if (!colorsStatements.length && !safeColorsStatements.length) return null;
+
+	for (const statement of safeColorsStatements) {
+		processStatement(rootNode, statement, edits, true);
+	}
+
+	for (const statement of colorsStatements) {
+		processStatement(rootNode, statement, edits, false);
+	}
+
+	if (!edits.length) return null;
+
+	return rootNode.commitEdits(edits);
+}
+
+function processStatement(
+	rootNode: SgNode<Js>,
+	statement: SgNode<Js>,
+	edits: Edit[],
+	isSafeImport: boolean,
+): void {
+	const initialEditCount = edits.length;
+	const destructuredNames = getDestructuredNames(statement);
+	const blockedPrototypeBases = new Set<string>();
+
+	if (destructuredNames.length > 0) {
+		processDestructuredSafeCalls(rootNode, destructuredNames, edits);
+	} else {
+		const binding = resolveOptionalBinding(statement);
+
+		if (binding) {
+			blockedPrototypeBases.add(binding);
+			processSafeNamespaceCalls(rootNode, binding, edits);
+		}
+	}
+
+	if (!isSafeImport) {
+		processPrototypeStyles(rootNode, edits, blockedPrototypeBases);
+	}
+
+	if (edits.length > initialEditCount) {
+		const importReplacement = createImportReplacement(statement);
+
+		if (importReplacement) {
+			edits.push(statement.replace(importReplacement));
+		}
+	}
+}
+
+function resolveOptionalBinding(statement: SgNode<Js>): string | undefined {
+	if (
+		statement.kind() === 'import_statement' &&
+		!statement.find({ rule: { kind: 'import_clause' } })
+	) {
+		return undefined;
+	}
+
+	return resolveBindingPath(statement, '$');
+}
+
+function getDestructuredNames(
+	statement: SgNode<Js>,
+): Array<{ imported: string; local: string }> {
+	const names: Array<{ imported: string; local: string }> = [];
+
+	if (statement.kind() === 'import_statement') {
+		const namedImports = statement.find({
+			rule: { kind: 'named_imports' },
+		});
+
+		if (!namedImports) return names;
+
+		const importSpecifiers = namedImports.findAll({
+			rule: { kind: 'import_specifier' },
+		});
+
+		for (const specifier of importSpecifiers) {
+			const importedName = specifier.field('name');
+			const alias = specifier.field('alias');
+
+			if (importedName) {
+				const imported = importedName.text();
+				names.push({ imported, local: alias ? alias.text() : imported });
+			}
+		}
+	} else if (statement.kind() === 'variable_declarator') {
+		const nameField = statement.field('name');
+
+		if (nameField?.kind() !== 'object_pattern') return names;
+
+		const properties = nameField.findAll({
+			rule: {
+				any: [
+					{ kind: 'shorthand_property_identifier_pattern' },
+					{ kind: 'pair_pattern' },
+				],
+			},
+		});
+
+		for (const prop of properties) {
+			if (prop.kind() === 'shorthand_property_identifier_pattern') {
+				const name = prop.text();
+
+				names.push({ imported: name, local: name });
+			} else if (prop.kind() === 'pair_pattern') {
+				const key = prop.field('key');
+				const value = prop.field('value');
+
+				if (key && value) {
+					names.push({ imported: key.text(), local: value.text() });
+				}
+			}
+		}
+	}
+
+	return names;
+}
+
+function processDestructuredSafeCalls(
+	rootNode: SgNode<Js>,
+	destructuredNames: Array<{ imported: string; local: string }>,
+	edits: Edit[],
+): void {
+	for (const { imported, local } of destructuredNames) {
+		const calls = rootNode.findAll({
+			rule: {
+				kind: 'call_expression',
+				has: {
+					field: 'function',
+					any: [
+						{ kind: 'identifier', pattern: local },
+						{
+							kind: 'member_expression',
+							has: {
+								field: 'object',
+								any: [
+									{ kind: 'identifier', pattern: local },
+									{
+										kind: 'member_expression',
+										has: {
+											field: 'object',
+											kind: 'identifier',
+											pattern: local,
+										},
+									},
+								],
+							},
+						},
+					],
+				},
+			},
+		});
+
+		for (const call of calls) {
+			const functionExpr = call.field('function');
+			if (!functionExpr) continue;
+
+			const styles =
+				functionExpr.kind() === 'identifier'
+					? [normalizeStyle(imported)]
+					: extractNamespaceStyles(functionExpr, local, normalizeStyle(imported));
+
+			replaceSafeCall(rootNode, call, styles, edits);
+		}
+	}
+}
+
+function processSafeNamespaceCalls(
+	rootNode: SgNode<Js>,
+	binding: string,
+	edits: Edit[],
+): void {
+	const calls = rootNode.findAll({
+		rule: { kind: 'call_expression' },
+	});
+
+	for (const call of calls) {
+		const functionExpr = call.field('function');
+
+		if (functionExpr?.kind() !== 'member_expression') continue;
+
+		const styles = extractNamespaceStyles(functionExpr, binding);
+		replaceSafeCall(rootNode, call, styles, edits);
+	}
+}
+
+function replaceSafeCall(
+	rootNode: SgNode<Js>,
+	call: SgNode<Js>,
+	styles: string[],
+	edits: Edit[],
+): void {
+	if (styles.length === 0) return;
+
+	if (hasUnsupportedStyles(styles)) {
+		warnOnUnsupportedStyle(styles, rootNode, call);
+		return;
+	}
+
+	const textArg = getFirstCallArgument(call);
+
+	if (!textArg) return;
+
+	edits.push(call.replace(createStyleTextReplacement(styles, textArg)));
+}
+
+function processPrototypeStyles(
+	rootNode: SgNode<Js>,
+	edits: Edit[],
+	blockedPrototypeBases: Set<string>,
+): void {
+	const memberExpressions = rootNode.findAll({
+		rule: { kind: 'member_expression' },
+	});
+
+	for (const memberExpression of memberExpressions) {
+		if (isNestedStyleChain(memberExpression)) continue;
+		if (isCallFunction(memberExpression)) continue;
+
+		const prototypeStyle = extractPrototypeStyles(memberExpression);
+
+		if (!prototypeStyle) continue;
+		if (blockedPrototypeBases.has(prototypeStyle.text)) continue;
+
+		if (hasUnsupportedStyles(prototypeStyle.styles)) {
+			warnOnUnsupportedStyle(prototypeStyle.styles, rootNode, memberExpression);
+			continue;
+		}
+
+		edits.push(
+			memberExpression.replace(
+				createStyleTextReplacement(prototypeStyle.styles, prototypeStyle.text),
+			),
+		);
+	}
+}
+
+function extractNamespaceStyles(
+	node: SgNode<Js>,
+	binding: string,
+	initialStyle?: string,
+): string[] {
+	const styles = initialStyle ? [initialStyle] : [];
+
+	function traverse(current: SgNode<Js>): boolean {
+		const object = current.field('object');
+		const property = current.field('property');
+
+		if (!object || property?.kind() !== 'property_identifier') return false;
+
+		const propertyName = normalizeStyle(property.text());
+
+		if (object.kind() === 'identifier' && object.text() === binding) {
+			styles.push(propertyName);
+			return true;
+		}
+
+		if (object.kind() === 'member_expression' && traverse(object)) {
+			styles.push(propertyName);
+			return true;
+		}
+
+		return false;
+	}
+
+	traverse(node);
+
+	return styles;
+}
+
+function extractPrototypeStyles(
+	node: SgNode<Js>,
+): { text: string; styles: string[] } | null {
+	const property = node.field('property');
+	const object = node.field('object');
+
+	if (!object || property?.kind() !== 'property_identifier') return null;
+
+	const style = normalizeStyle(property.text());
+
+	if (!isSupportedOrKnownUnsupported(style)) return null;
+
+	if (object.kind() === 'member_expression') {
+		const nested = extractPrototypeStyles(object);
+
+		if (!nested) return null;
+
+		return { text: nested.text, styles: [...nested.styles, style] };
+	}
+
+	if (!isSupportedPrototypeBase(object)) return null;
+
+	return { text: object.text(), styles: [style] };
+}
+
+function isSupportedPrototypeBase(node: SgNode<Js>): boolean {
+	return [
+		'identifier',
+		'parenthesized_expression',
+		'string',
+		'template_string',
+	].includes(node.kind());
+}
+
+function normalizeStyle(style: string): string {
+	return COMPAT_MAP[style] || style;
+}
+
+function isSupportedOrKnownUnsupported(style: string): boolean {
+	return SUPPORTED_STYLES.has(style) || UNSUPPORTED_EXTRAS.has(style);
+}
+
+function hasUnsupportedStyles(styles: string[]): boolean {
+	return styles.some((style) => !SUPPORTED_STYLES.has(style));
+}
+
+function getFirstCallArgument(call: SgNode<Js>): string | null {
+	const args = call.field('arguments');
+
+	if (!args) return null;
+
+	const argsList = args.children().filter((child) => {
+		const excluded = [',', '(', ')'];
+		return !excluded.includes(child.kind());
+	});
+
+	if (argsList.length === 0) return null;
+
+	return argsList[0].text();
+}
+
+function createStyleTextReplacement(styles: string[], textArg: string): string {
+	if (styles.length === 1) {
+		return `styleText("${styles[0]}", ${textArg})`;
+	}
+
+	return `styleText([${styles.map((style) => `"${style}"`).join(', ')}], ${textArg})`;
+}
+
+function createImportReplacement(statement: SgNode<Js>): string {
+	if (statement.kind() === 'import_statement') {
+		return 'import { styleText } from "node:util";';
+	}
+
+	if (statement.kind() === 'variable_declarator') {
+		if (statement.field('value')?.kind() === 'await_expression') {
+			return '{ styleText } = await import("node:util")';
+		}
+
+		return '{ styleText } = require("node:util")';
+	}
+
+	return '';
+}
+
+function isNestedStyleChain(node: SgNode<Js>): boolean {
+	const parent = node.parent();
+
+	if (parent?.kind() !== 'member_expression') return false;
+
+	const object = parent.field('object');
+	const property = parent.field('property');
+
+	return (
+		object?.text() === node.text() &&
+		property?.kind() === 'property_identifier' &&
+		isSupportedOrKnownUnsupported(normalizeStyle(property.text()))
+	);
+}
+
+function isCallFunction(node: SgNode<Js>): boolean {
+	const parent = node.parent();
+
+	if (parent?.kind() !== 'call_expression') return false;
+
+	return parent.field('function')?.text() === node.text();
+}
+
+function warnOnUnsupportedStyle(
+	styles: string[],
+	rootNode: SgNode<Js>,
+	node: SgNode<Js>,
+): void {
+	const filename = rootNode.getRoot().filename();
+	const { start } = node.range();
+	const unsupported = styles.filter((style) => !SUPPORTED_STYLES.has(style));
+
+	for (const style of unsupported) {
+		console.warn(
+			`${filename}:${start.line}:${start.column}: uses colors style '${style}' that does not have any equivalent in util.styleText; please review this line`,
+		);
+	}
+}

--- a/recipes/colors-to-util-styletext/src/workflow.ts
+++ b/recipes/colors-to-util-styletext/src/workflow.ts
@@ -96,7 +96,7 @@ function processStatement(
 	edits: Edit[],
 	isSafeImport: boolean,
 ): void {
-	const initialEditCount = edits.length;
+	const editCountBeforeStatement = edits.length;
 	const destructuredNames = getDestructuredNames(statement);
 	const blockedPrototypeBases = new Set<string>();
 
@@ -115,7 +115,7 @@ function processStatement(
 		processPrototypeStyles(rootNode, edits, blockedPrototypeBases);
 	}
 
-	if (edits.length > initialEditCount) {
+	if (edits.length > editCountBeforeStatement) {
 		const importReplacement = createImportReplacement(statement);
 
 		if (importReplacement) {
@@ -143,60 +143,65 @@ function getDestructuredNames(
 	const names: Array<{ imported: string; local: string }> = [];
 	const statementKind = statement.kind();
 
-	if (statementKind === 'import_statement') {
-		const namedImports = statement.find({
-			rule: { kind: 'named_imports' },
-		});
+	switch (statementKind) {
+		case 'import_statement': {
+			const namedImports = statement.find({
+				rule: { kind: 'named_imports' },
+			});
 
-		if (!namedImports) return names;
+			if (!namedImports) break;
 
-		const importSpecifiers = namedImports.findAll({
-			rule: { kind: 'import_specifier' },
-		});
+			const importSpecifiers = namedImports.findAll({
+				rule: { kind: 'import_specifier' },
+			});
 
-		for (const specifier of importSpecifiers) {
-			const importedName = specifier.field('name');
-			const alias = specifier.field('alias');
+			for (const specifier of importSpecifiers) {
+				const importedName = specifier.field('name');
+				const alias = specifier.field('alias');
 
-			if (importedName) {
-				const imported = importedName.text();
-				names.push({ imported, local: alias ? alias.text() : imported });
+				if (importedName) {
+					const imported = importedName.text();
+					names.push({ imported, local: alias ? alias.text() : imported });
+				}
 			}
+			break;
 		}
-	} else if (statementKind === 'variable_declarator') {
-		const nameField = statement.field('name');
+		case 'variable_declarator': {
+			const nameField = statement.field('name');
 
-		if (nameField?.kind() !== 'object_pattern') return names;
+			if (nameField?.kind() !== 'object_pattern') break;
 
-		const properties = nameField.findAll({
-			rule: {
-				any: [
-					{ kind: 'shorthand_property_identifier_pattern' },
-					{ kind: 'pair_pattern' },
-				],
-			},
-		});
+			const properties = nameField.findAll({
+				rule: {
+					any: [
+						{ kind: 'shorthand_property_identifier_pattern' },
+						{ kind: 'pair_pattern' },
+					],
+				},
+			});
 
-		for (const prop of properties) {
-			const propKind = prop.kind();
+			for (const prop of properties) {
+				const propKind = prop.kind();
 
-			switch (propKind) {
-				case 'shorthand_property_identifier_pattern': {
-					const name = prop.text();
+				switch (propKind) {
+					case 'shorthand_property_identifier_pattern': {
+						const name = prop.text();
 
-					names.push({ imported: name, local: name });
-					break;
-				}
-				case 'pair_pattern': {
-					const key = prop.field('key');
-					const value = prop.field('value');
-
-					if (key && value) {
-						names.push({ imported: key.text(), local: value.text() });
+						names.push({ imported: name, local: name });
+						break;
 					}
-					break;
+					case 'pair_pattern': {
+						const key = prop.field('key');
+						const value = prop.field('value');
+
+						if (key && value) {
+							names.push({ imported: key.text(), local: value.text() });
+						}
+						break;
+					}
 				}
 			}
+			break;
 		}
 	}
 

--- a/recipes/colors-to-util-styletext/tests/basic-property/expected.js
+++ b/recipes/colors-to-util-styletext/tests/basic-property/expected.js
@@ -1,0 +1,3 @@
+const { styleText } = require("node:util");
+
+console.log(styleText("red", "Error message"));

--- a/recipes/colors-to-util-styletext/tests/basic-property/input.js
+++ b/recipes/colors-to-util-styletext/tests/basic-property/input.js
@@ -1,0 +1,3 @@
+const colors = require("colors");
+
+console.log("Error message".red);

--- a/recipes/colors-to-util-styletext/tests/chained-property/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/chained-property/expected.mjs
@@ -1,0 +1,3 @@
+import { styleText } from "node:util";
+
+console.log(styleText(["green", "bold"], "Success message"));

--- a/recipes/colors-to-util-styletext/tests/chained-property/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/chained-property/input.mjs
@@ -1,0 +1,3 @@
+import colors from "colors";
+
+console.log("Success message".green.bold);

--- a/recipes/colors-to-util-styletext/tests/concat-and-template/expected.js
+++ b/recipes/colors-to-util-styletext/tests/concat-and-template/expected.js
@@ -1,0 +1,6 @@
+const { styleText } = require("node:util");
+
+const name = "World";
+const action = "ready";
+console.log("Hello, " + styleText("green", name) + "!");
+console.log(`${styleText("blue", "[INFO]")} User ${styleText("green", name)} is ${styleText("yellow", action)}`);

--- a/recipes/colors-to-util-styletext/tests/concat-and-template/input.js
+++ b/recipes/colors-to-util-styletext/tests/concat-and-template/input.js
@@ -1,0 +1,6 @@
+const colors = require("colors");
+
+const name = "World";
+const action = "ready";
+console.log("Hello, " + name.green + "!");
+console.log(`${"[INFO]".blue} User ${name.green} is ${action.yellow}`);

--- a/recipes/colors-to-util-styletext/tests/destructured-safe/expected.js
+++ b/recipes/colors-to-util-styletext/tests/destructured-safe/expected.js
@@ -1,0 +1,4 @@
+const { styleText } = require("node:util");
+
+console.log(styleText("red", "Error message"));
+console.log(styleText("green", "Success message"));

--- a/recipes/colors-to-util-styletext/tests/destructured-safe/input.js
+++ b/recipes/colors-to-util-styletext/tests/destructured-safe/input.js
@@ -1,0 +1,4 @@
+const { red, green: success } = require("colors/safe");
+
+console.log(red("Error message"));
+console.log(success("Success message"));

--- a/recipes/colors-to-util-styletext/tests/remove-dependencies/remove-colors/expected.json
+++ b/recipes/colors-to-util-styletext/tests/remove-dependencies/remove-colors/expected.json
@@ -1,0 +1,10 @@
+{
+  "name": "fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "kleur": "^4.1.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/recipes/colors-to-util-styletext/tests/remove-dependencies/remove-colors/input.json
+++ b/recipes/colors-to-util-styletext/tests/remove-dependencies/remove-colors/input.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "colors": "^1.4.0",
+    "kleur": "^4.1.5"
+  },
+  "devDependencies": {
+    "@types/colors": "^1.2.1",
+    "typescript": "^5.6.0"
+  }
+}

--- a/recipes/colors-to-util-styletext/tests/safe-chained-esm/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-chained-esm/expected.mjs
@@ -1,0 +1,3 @@
+import { styleText } from "node:util";
+
+console.log(styleText(["green", "bold"], "Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-chained-esm/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-chained-esm/input.mjs
@@ -1,0 +1,3 @@
+import colors from "colors/safe";
+
+console.log(colors.green.bold("Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-commonjs/expected.js
+++ b/recipes/colors-to-util-styletext/tests/safe-commonjs/expected.js
@@ -1,0 +1,3 @@
+const { styleText } = require("node:util");
+
+console.log(styleText("green", "Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-commonjs/input.js
+++ b/recipes/colors-to-util-styletext/tests/safe-commonjs/input.js
@@ -1,0 +1,3 @@
+const colors = require("colors/safe");
+
+console.log(colors.green("Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-dynamic-import-await/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-dynamic-import-await/expected.mjs
@@ -1,0 +1,4 @@
+const { styleText } = await import("node:util");
+
+console.log(styleText("red", "Error message"));
+console.log(styleText("green", "Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-dynamic-import-await/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-dynamic-import-await/input.mjs
@@ -1,0 +1,4 @@
+const { red, green: success } = await import("colors/safe");
+
+console.log(red("Error message"));
+console.log(success("Success message"));

--- a/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/expected.mjs
@@ -1,0 +1,3 @@
+import("colors/safe").then(({ green }) => {
+	console.log(green("Success message"));
+});

--- a/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/expected.mjs
@@ -1,3 +1,3 @@
-import("colors/safe").then(({ green }) => {
-	console.log(green("Success message"));
+import("node:util").then(({ styleText }) => {
+	console.log(styleText("green", "Success message"));
 });

--- a/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/safe-dynamic-import-then/input.mjs
@@ -1,0 +1,3 @@
+import("colors/safe").then(({ green }) => {
+	console.log(green("Success message"));
+});

--- a/recipes/colors-to-util-styletext/tests/safe-unrelated-call/expected.js
+++ b/recipes/colors-to-util-styletext/tests/safe-unrelated-call/expected.js
@@ -1,3 +1,3 @@
-const colors = require("colors/safe");
+
 
 console.log("plain message");

--- a/recipes/colors-to-util-styletext/tests/safe-unrelated-call/expected.js
+++ b/recipes/colors-to-util-styletext/tests/safe-unrelated-call/expected.js
@@ -1,0 +1,3 @@
+const colors = require("colors/safe");
+
+console.log("plain message");

--- a/recipes/colors-to-util-styletext/tests/safe-unrelated-call/input.js
+++ b/recipes/colors-to-util-styletext/tests/safe-unrelated-call/input.js
@@ -1,0 +1,3 @@
+const colors = require("colors/safe");
+
+console.log("plain message");

--- a/recipes/colors-to-util-styletext/tests/side-effect-import/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/side-effect-import/expected.mjs
@@ -1,3 +1,4 @@
 import { styleText } from "node:util";
 
 console.log(styleText("red", "Error message"));
+console.log(styleText(["yellow", "bold"], "Warning message"));

--- a/recipes/colors-to-util-styletext/tests/side-effect-import/expected.mjs
+++ b/recipes/colors-to-util-styletext/tests/side-effect-import/expected.mjs
@@ -1,0 +1,3 @@
+import { styleText } from "node:util";
+
+console.log(styleText("red", "Error message"));

--- a/recipes/colors-to-util-styletext/tests/side-effect-import/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/side-effect-import/input.mjs
@@ -1,3 +1,4 @@
 import "colors";
 
 console.log("Error message".red);
+console.log("Warning message".yellow.bold);

--- a/recipes/colors-to-util-styletext/tests/side-effect-import/input.mjs
+++ b/recipes/colors-to-util-styletext/tests/side-effect-import/input.mjs
@@ -1,0 +1,3 @@
+import "colors";
+
+console.log("Error message".red);

--- a/recipes/colors-to-util-styletext/tests/unsupported-extra/expected.js
+++ b/recipes/colors-to-util-styletext/tests/unsupported-extra/expected.js
@@ -1,0 +1,3 @@
+const colors = require("colors");
+
+console.log("Party".rainbow);

--- a/recipes/colors-to-util-styletext/tests/unsupported-extra/input.js
+++ b/recipes/colors-to-util-styletext/tests/unsupported-extra/input.js
@@ -1,0 +1,3 @@
+const colors = require("colors");
+
+console.log("Party".rainbow);

--- a/recipes/colors-to-util-styletext/workflow.yaml
+++ b/recipes/colors-to-util-styletext/workflow.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/codemod-com/codemod/refs/heads/main/schemas/workflow.json
+
+version: "1"
+
+nodes:
+  - id: apply-transforms
+    name: Apply AST Transformations
+    type: automatic
+    steps:
+      - name: Migrate from the colors package to Node.js's built-in util.styleText API
+        js-ast-grep:
+          js_file: src/workflow.ts
+          base_path: .
+          include:
+            - "**/*.cjs"
+            - "**/*.cts"
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.mjs"
+            - "**/*.mts"
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript
+
+  - id: remove-dependencies
+    name: Remove colors dependency
+    type: automatic
+    steps:
+      - name: Detect package manager and remove colors dependency
+        js-ast-grep:
+          js_file: src/remove-dependencies.ts
+          base_path: .
+          include:
+            - "**/package.json"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript
+          capabilities:
+            - child_process
+            - fs


### PR DESCRIPTION
Fixes #474

Adds a colors-to-util.styleText recipe for compatible colors usage:
- string prototype colors and chained modifiers
- colors/safe namespace and destructured calls
- package.json dependency removal

Unsupported extras are left unchanged with a warning for manual review.

Checks:
- npm test --workspace=recipes/colors-to-util-styletext
- npm run type-check
- npm run lint
- git diff --check