### PR TITLE
fix(mocha-to-node): wrong author name

### DIFF
--- a/recipes/mocha-to-node-test-runner/package.json
+++ b/recipes/mocha-to-node-test-runner/package.json
@@ -12,7 +12,7 @@
     "directory": "recipes/mocha-to-node-test-runner",
     "bugs": "https://github.com/nodejs/userland-migrations/issues"
   },
-  "author": "Richie McColl",
+  "author": "Xavier Stouder",
   "license": "MIT",
   "homepage": "https://github.com/nodejs/userland-migrations/blob/main/recipes/mocha-to-node-test-runner/README.md",
   "devDependencies": {


### PR DESCRIPTION
I'm sorry, I may have forgotten that when copying and pasting from another recipe.